### PR TITLE
Removed commented code; formatting

### DIFF
--- a/health/health.go
+++ b/health/health.go
@@ -50,51 +50,6 @@ func (h *Health) SendEvent(healthFunc HealthFunc) {
 	h.event <- healthFunc
 }
 
-// Memory returns a HealthFunc that updates the given stats with memory statistics,
-// based on the operation system name.
-//func Memory(log logging.Logger, osChecker OsChecker) HealthFunc {
-//	osName := osChecker.OsName()
-//	log.Info("Operating system detected: %s", osName)
-//
-//	switch osName {
-//	case "linux":
-//		return func(stats Stats) {
-//			meminfo, err := linux.ReadMemInfo("/proc/meminfo")
-//			if err != nil {
-//				log.Error("error querying memory information: %v", err)
-//				return
-//			}
-//
-//			active := int(meminfo.Active * 1024)
-//			stats[CurrentMemoryUtilizationActive] = active
-//			if active > stats[MaxMemoryUtilizationActive] {
-//				stats[MaxMemoryUtilizationActive] = active
-//			}
-//
-//			var memstats runtime.MemStats
-//			runtime.ReadMemStats(&memstats)
-//			alloc := int(memstats.Alloc)
-//			heapsys := int(memstats.HeapSys)
-//
-//			// set current
-//			stats[CurrentMemoryUtilizationAlloc] = alloc
-//			stats[CurrentMemoryUtilizationHeapSys] = heapsys
-//
-//			// set max
-//			if alloc > stats[MaxMemoryUtilizationAlloc] {
-//				stats[MaxMemoryUtilizationAlloc] = alloc
-//			}
-//
-//			if heapsys > stats[MaxMemoryUtilizationHeapSys] {
-//				stats[MaxMemoryUtilizationHeapSys] = heapsys
-//			}
-//		}
-//	default:
-//		// return a noop
-//		return func(Stats) {}
-//	}
-//}
-
 // Close shuts down the health event monitoring
 func (h *Health) Close() error {
 	close(h.event)

--- a/health/health.go
+++ b/health/health.go
@@ -57,7 +57,7 @@ func (h *Health) Close() error {
 }
 
 // New creates a Health object with the given statistics.
-func New(interval time.Duration, log logging.Logger, options ...HealthFunc) *Health {
+func New(interval time.Duration, log logging.Logger, options ...Option) *Health {
 	initialStats := commonStats.Clone()
 	initialStats.Apply(options...)
 

--- a/health/memInfoReader_test.go
+++ b/health/memInfoReader_test.go
@@ -10,7 +10,7 @@ func TestLinuxRead(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
-	
+
 	if memInfo == nil {
 		t.Fatalf("No MemInfo returned")
 	}
@@ -22,7 +22,7 @@ func TestNonLinunxRead(t *testing.T) {
 	if err == nil {
 		t.Errorf("No error returned")
 	}
-	
+
 	if memInfo != nil {
 		t.Errorf("A MemInfo should not have been returned: %v", *memInfo)
 	}

--- a/health/stat_test.go
+++ b/health/stat_test.go
@@ -185,61 +185,61 @@ func TestUpdateMemInfo(t *testing.T) {
 }
 
 func TestUpdateMemStats(t *testing.T) {
-	var testData = []struct{
+	var testData = []struct {
 		memStats runtime.MemStats
-		initial Stats
+		initial  Stats
 		expected Stats
 	}{
 		// empty initial Stats
 		{
 			runtime.MemStats{
-				Alloc: 247,
+				Alloc:   247,
 				HeapSys: 2381,
 			},
 			Stats{},
 			Stats{
-				CurrentMemoryUtilizationAlloc: 247,
-				MaxMemoryUtilizationAlloc: 247,
+				CurrentMemoryUtilizationAlloc:   247,
+				MaxMemoryUtilizationAlloc:       247,
 				CurrentMemoryUtilizationHeapSys: 2381,
-				MaxMemoryUtilizationHeapSys: 2381,
+				MaxMemoryUtilizationHeapSys:     2381,
 			},
 		},
 		// current is less than max
 		{
 			runtime.MemStats{
-				Alloc: 3874,
+				Alloc:   3874,
 				HeapSys: 1234,
 			},
 			Stats{
-				CurrentMemoryUtilizationAlloc: 12354,
-				MaxMemoryUtilizationAlloc: 927412,
+				CurrentMemoryUtilizationAlloc:   12354,
+				MaxMemoryUtilizationAlloc:       927412,
 				CurrentMemoryUtilizationHeapSys: 7897,
-				MaxMemoryUtilizationHeapSys: 827123,
+				MaxMemoryUtilizationHeapSys:     827123,
 			},
 			Stats{
-				CurrentMemoryUtilizationAlloc: 3874,
-				MaxMemoryUtilizationAlloc: 927412,
+				CurrentMemoryUtilizationAlloc:   3874,
+				MaxMemoryUtilizationAlloc:       927412,
 				CurrentMemoryUtilizationHeapSys: 1234,
-				MaxMemoryUtilizationHeapSys: 827123,
+				MaxMemoryUtilizationHeapSys:     827123,
 			},
 		},
 		// current is greater than max
 		{
 			runtime.MemStats{
-				Alloc: 8742,
+				Alloc:   8742,
 				HeapSys: 2903209,
 			},
 			Stats{
-				CurrentMemoryUtilizationAlloc: 135,
-				MaxMemoryUtilizationAlloc: 1254,
+				CurrentMemoryUtilizationAlloc:   135,
+				MaxMemoryUtilizationAlloc:       1254,
 				CurrentMemoryUtilizationHeapSys: 5412,
-				MaxMemoryUtilizationHeapSys: 12345,
+				MaxMemoryUtilizationHeapSys:     12345,
 			},
 			Stats{
-				CurrentMemoryUtilizationAlloc: 8742,
-				MaxMemoryUtilizationAlloc: 8742,
+				CurrentMemoryUtilizationAlloc:   8742,
+				MaxMemoryUtilizationAlloc:       8742,
 				CurrentMemoryUtilizationHeapSys: 2903209,
-				MaxMemoryUtilizationHeapSys: 2903209,
+				MaxMemoryUtilizationHeapSys:     2903209,
 			},
 		},
 	}


### PR DESCRIPTION
This is actually a larger pull request, since I screwed up and pushed to master.

The key design change is the realization that it's not the OS that you want to vary.  It's how memory stats are read.  I've refactored into a simpler approach that encapsulates reading MemInfo data behind it's own configurable type.