### PR TITLE
Feature/key value

### DIFF
--- a/concurrent/keyValue.go
+++ b/concurrent/keyValue.go
@@ -1,0 +1,141 @@
+package concurrent
+
+import (
+	"sync"
+)
+
+// KeyValueStorage is the map type used by KeyValue.  It is the type that is
+// directly modifiable by operations.
+type KeyValueStorage map[interface{}]interface{}
+
+// KeyValueOperation represents an atomic operation that is allowed to mutate the
+// storage of a KeyValue.  Operations are always executed within a critical
+// section bounded by a write lock.
+type KeyValueOperation interface {
+	Execute(KeyValueStorage)
+}
+
+// KeyValueOperationFunc is a function type that implements KeyValueOperation.
+type KeyValueOperationFunc func(KeyValueStorage)
+
+func (f KeyValueOperationFunc) Execute(storage KeyValueStorage) {
+	f(storage)
+}
+
+// KeyValueTransformer is a binary operation that produces a result from a key/value pair.
+// Transformers cannot mutate the storage of a KeyValue.  Transformers are always
+// executed within the context of a read lock.  Multiple transformers can execute
+// simultaneously.
+type KeyValueTransformer interface {
+	Execute(key, value interface{}) interface{}
+}
+
+// KeyValueTransformerFunc is a function type that implements KeyValueTransformer.
+type KeyValueTransformerFunc func(key, value interface{}) interface{}
+
+func (f KeyValueTransformerFunc) Execute(key, value interface{}) interface{} {
+	return f(key, value)
+}
+
+// KeyValue is a concurrent mapping of arbitrary types with a completely asynchronous API.
+// Instances of this type must be created via NewKeyValue.
+type KeyValue struct {
+	storage KeyValueStorage
+	lock    sync.RWMutex
+}
+
+// NewKeyValue initializes and returns a distinct KeyValue instance.
+func NewKeyValue() *KeyValue {
+	return &KeyValue{
+		storage: make(KeyValueStorage),
+	}
+}
+
+// Apply uses the given transformer to produce a result for each key/value pair in the storage.
+// A channel of channels is returned: The channel has a buffer size of 1 and will receive another
+// channel containing the results of applying the transformer.
+func (kv *KeyValue) Apply(transformer KeyValueTransformer) <-chan chan interface{} {
+	output := make(chan chan interface{}, 1)
+	go func() {
+		kv.lock.RLock()
+		defer kv.lock.RUnlock()
+		defer close(output)
+
+		results := make(chan interface{}, len(kv.storage))
+		defer close(results)
+		output <- results
+
+		for key, value := range kv.storage {
+			results <- transformer.Execute(key, value)
+		}
+	}()
+
+	return output
+}
+
+// Keys is a special usage of Apply:  It returns a channel which in turn receives a channel
+// containing the keys in the internal storage.
+func (kv *KeyValue) Keys() <-chan chan interface{} {
+	return kv.Apply(
+		KeyValueTransformerFunc(
+			func(key, value interface{}) interface{} { return key },
+		),
+	)
+}
+
+// Values is a special usage of Apply:  It returns a channel which in turn receives a channel
+// containing the values in the internal storage.
+func (kv *KeyValue) Values() <-chan chan interface{} {
+	return kv.Apply(
+		KeyValueTransformerFunc(
+			func(key, value interface{}) interface{} { return value },
+		),
+	)
+}
+
+// Do asynchronously executes a bulk operation against the internal storage.
+// This method contends on the internal write lock.
+func (kv *KeyValue) Do(operation KeyValueOperation) {
+	go func() {
+		kv.lock.Lock()
+		defer kv.lock.Unlock()
+		operation.Execute(kv.storage)
+	}()
+}
+
+// Get asynchronously obtains the value associated with the given key.  The returned
+// channel always receives exactly one (1) value.  It will receive nil if the given
+// key was not present in the storage.
+func (kv *KeyValue) Get(key interface{}) <-chan interface{} {
+	output := make(chan interface{}, 1)
+	go func() {
+		kv.lock.RLock()
+		defer kv.lock.RUnlock()
+		defer close(output)
+		output <- kv.storage[key]
+	}()
+
+	return output
+}
+
+// Add asynchronously adds (or, replaces) a key/value pair.
+func (kv *KeyValue) Add(key, value interface{}) {
+	go func() {
+		kv.lock.Lock()
+		defer kv.lock.Unlock()
+		kv.storage[key] = value
+	}()
+}
+
+// Delete asynchronously removes zero or more keys from the internal storage.
+func (kv *KeyValue) Delete(keys ...interface{}) {
+	if len(keys) > 0 {
+		go func() {
+			kv.lock.Lock()
+			defer kv.lock.Unlock()
+			for _, key := range keys {
+				delete(kv.storage, key)
+			}
+		}()
+	}
+}

--- a/concurrent/keyValue_test.go
+++ b/concurrent/keyValue_test.go
@@ -1,0 +1,139 @@
+package concurrent
+
+import (
+	"github.com/stretchr/testify/assert"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestKeyValueEmpty(t *testing.T) {
+	assert := assert.New(t)
+	testWaitGroup := &sync.WaitGroup{}
+
+	keyValue := NewKeyValue()
+	if !assert.NotNil(keyValue) {
+		return
+	}
+
+	assert.Nil(<-keyValue.Get(1))
+
+	testWaitGroup.Add(1)
+	keyValue.Do(
+		KeyValueOperationFunc(func(storage KeyValueStorage) {
+			defer testWaitGroup.Done()
+			assert.Equal(0, len(storage))
+		}),
+	)
+	testWaitGroup.Wait()
+
+	for _ = range <-keyValue.Keys() {
+		t.Error("Should not have received any keys in an empty KeyValue")
+	}
+
+	for _ = range <-keyValue.Values() {
+		t.Error("Should not have received any values in an empty KeyValue")
+	}
+}
+
+func TestKeyValueBasics(t *testing.T) {
+	assert := assert.New(t)
+	testWaitGroup := &sync.WaitGroup{}
+
+	keyValue := NewKeyValue()
+	if !assert.NotNil(keyValue) {
+		return
+	}
+
+	keyValue.Add(1, "one")
+	keyValue.Add(2, "two")
+	keyValue.Add(3, "three")
+	time.Sleep(50 * time.Millisecond)
+
+	assert.Equal("one", <-keyValue.Get(1))
+	assert.Equal("two", <-keyValue.Get(2))
+	assert.Equal("three", <-keyValue.Get(3))
+	assert.Nil(<-keyValue.Get(-192347192874918273))
+
+	testWaitGroup.Add(1)
+	keyValue.Do(
+		KeyValueOperationFunc(func(storage KeyValueStorage) {
+			defer testWaitGroup.Done()
+			assert.Equal(
+				KeyValueStorage(map[interface{}]interface{}{
+					1: "one",
+					2: "two",
+					3: "three",
+				}),
+				storage,
+			)
+		}),
+	)
+	testWaitGroup.Wait()
+
+	{
+		expectedKeys := []int{1, 2, 3}
+		sort.Ints(expectedKeys)
+		actualKeys := []int{}
+		for key := range <-keyValue.Keys() {
+			actualKeys = append(actualKeys, key.(int))
+		}
+
+		sort.Ints(actualKeys)
+		assert.Equal(expectedKeys, actualKeys)
+	}
+
+	{
+		expectedValues := []string{"one", "two", "three"}
+		sort.Strings(expectedValues)
+		actualValues := []string{}
+		for value := range <-keyValue.Values() {
+			actualValues = append(actualValues, value.(string))
+		}
+
+		sort.Strings(actualValues)
+		assert.Equal(expectedValues, actualValues)
+	}
+
+	keyValue.Delete(1, 2)
+	time.Sleep(50 * time.Millisecond)
+
+	assert.Nil(<-keyValue.Get(1))
+	assert.Nil(<-keyValue.Get(2))
+	assert.Equal("three", <-keyValue.Get(3))
+
+	testWaitGroup.Add(1)
+	keyValue.Do(
+		KeyValueOperationFunc(func(storage KeyValueStorage) {
+			defer testWaitGroup.Done()
+			assert.Equal(
+				KeyValueStorage(map[interface{}]interface{}{
+					3: "three",
+				}),
+				storage,
+			)
+		}),
+	)
+	testWaitGroup.Wait()
+
+	{
+		expectedKeys := []int{3}
+		actualKeys := []int{}
+		for key := range <-keyValue.Keys() {
+			actualKeys = append(actualKeys, key.(int))
+		}
+
+		assert.Equal(expectedKeys, actualKeys)
+	}
+
+	{
+		expectedValues := []string{"three"}
+		actualValues := []string{}
+		for value := range <-keyValue.Values() {
+			actualValues = append(actualValues, value.(string))
+		}
+
+		assert.Equal(expectedValues, actualValues)
+	}
+}


### PR DESCRIPTION
KeyValue is a fully asynchronous key/value store .... or map.  It trades the convenience and simplicity of a synchronous API with a slightly more complex asynchronous API that permits more parallelism.

There are (3) types I've identified in WebPA that could use this type under the covers: (1) the Health monitor, (2) talaria's DeviceRegistry, and (3) scytale's channel map.  All (3) are data structures where calling code doesn't care about waiting on writes and only rarely does reads.