### PR TITLE
Feature/serversets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
     - TEST_DIR=secure/key
     - TEST_DIR=secure/tools/cmd/keyserver
     - TEST_DIR=server
+    - TEST_DIR=service
     - TEST_DIR=logging
     - TEST_DIR=logging/golog
     - TEST_DIR=store

--- a/Canticle
+++ b/Canticle
@@ -34,8 +34,5 @@
     {
         "Root": "github.com/SermoDigital/jose",
         "Revision": "2a2a7005e242469734d8d0d110f4bb657bb67759"
-    },
-    {
-        "Root": "golang.org/x/net/context"
     }
 ]

--- a/Canticle
+++ b/Canticle
@@ -34,5 +34,9 @@
     {
         "Root": "github.com/SermoDigital/jose",
         "Revision": "2a2a7005e242469734d8d0d110f4bb657bb67759"
+    },
+    {
+        "Root": "github.com/strava/go.serversets",
+        "Revision": "6b724900cd036a1da1f72c438b9e7f447446dcd2"
     }
 ]

--- a/service/accessor.go
+++ b/service/accessor.go
@@ -1,0 +1,85 @@
+package service
+
+import (
+	"github.com/Comcast/webpa-common/logging"
+	"github.com/billhathaway/consistentHash"
+)
+
+// Accessor provides access to services based around []byte keys.
+// *consistentHash.ConsistentHash implements this interface.
+type Accessor interface {
+	Get([]byte) (string, error)
+}
+
+// AccessorFactory is a Factory Interface for creating service Accessors.
+type AccessorFactory interface {
+	// New creates an Accessor using a slice of endpoints
+	New([]string) Accessor
+}
+
+// NewAccessoryFactory uses a set of Options to produce an AccessorFactory
+func NewAccessorFactory(o *Options) AccessorFactory {
+	return &consistentHashFactory{
+		logger:     o.logger(),
+		vnodeCount: o.vnodeCount(),
+	}
+}
+
+// consistentHashFactory creates consistentHash instances, which implement Accessor.
+// This is the standard implementation of AccessoryFactory.
+type consistentHashFactory struct {
+	logger     logging.Logger
+	vnodeCount int
+}
+
+func (f *consistentHashFactory) New(endpoints []string) Accessor {
+	hash := consistentHash.New()
+	hash.SetVnodeCount(f.vnodeCount)
+	for _, hostAndPort := range endpoints {
+		f.logger.Debug("adding %s", hostAndPort)
+		hash.Add(hostAndPort)
+	}
+
+	return hash
+}
+
+// Subscribe returns a channel which receives new Accessors when watch events occur.
+// The pipeline of Accessors can be used for rehashing.
+//
+// The returned channel will have a buffer size of one (1).  The goroutine which processes
+// watch events will block waiting for this channel to become writable.
+func Subscribe(o *Options, factory AccessorFactory, watcher Watcher) (<-chan Accessor, error) {
+	logger := o.logger()
+	watch, err := watcher.Watch()
+	if err != nil {
+		return nil, err
+	}
+
+	if factory == nil {
+		factory = NewAccessorFactory(o)
+	}
+
+	accessors := make(chan Accessor, 1)
+	go func() {
+		defer close(accessors)
+
+		endpoints := watch.Endpoints()
+		logger.Info("Initial discovered endpoints: %s", endpoints)
+		accessors <- factory.New(endpoints)
+
+		for {
+			select {
+			case <-watch.Event():
+				if watch.IsClosed() {
+					return
+				}
+
+				endpoints = watch.Endpoints()
+				logger.Info("Updated endpoints: %s", endpoints)
+				accessors <- factory.New(endpoints)
+			}
+		}
+	}()
+
+	return accessors, nil
+}

--- a/service/accessor_test.go
+++ b/service/accessor_test.go
@@ -1,0 +1,58 @@
+package service
+
+import (
+	"github.com/Comcast/webpa-common/logging"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestNewAccessorFactory(t *testing.T) {
+	assert := assert.New(t)
+	logger := logging.TestLogger(t)
+	testData := []struct {
+		endpoints    []string
+		expectsError bool
+	}{
+		{
+			nil,
+			true,
+		},
+		{
+			[]string{},
+			true,
+		},
+		{
+			[]string{"http://localhost:0101"},
+			false,
+		},
+		{
+			[]string{"https://host1.net:123", "http://host2.com:9293"},
+			false,
+		},
+	}
+
+	for _, record := range testData {
+		t.Logf("%v", record)
+
+		for _, vnodeCount := range []int{0, 200, 1700} {
+			factory := NewAccessorFactory(&Options{Logger: logger, VnodeCount: vnodeCount})
+			if !assert.NotNil(factory) {
+				continue
+			}
+
+			accessor := factory.New(record.endpoints)
+			if !assert.NotNil(accessor) {
+				continue
+			}
+
+			endpoint, err := accessor.Get([]byte("key"))
+			if record.expectsError {
+				assert.Empty(endpoint)
+				assert.Error(err)
+			} else {
+				assert.NotEmpty(endpoint)
+				assert.NoError(err)
+			}
+		}
+	}
+}

--- a/service/accessor_test.go
+++ b/service/accessor_test.go
@@ -34,7 +34,7 @@ func TestNewAccessorFactory(t *testing.T) {
 	for _, record := range testData {
 		t.Logf("%v", record)
 
-		for _, vnodeCount := range []int{0, 200, 1700} {
+		for _, vnodeCount := range []uint{0, 200, 1700} {
 			factory := NewAccessorFactory(&Options{Logger: logger, VnodeCount: vnodeCount})
 			if !assert.NotNil(factory) {
 				continue

--- a/service/doc.go
+++ b/service/doc.go
@@ -1,0 +1,4 @@
+/*
+Package service provides basic integration with go.serversets
+*/
+package service

--- a/service/mocks_test.go
+++ b/service/mocks_test.go
@@ -1,0 +1,45 @@
+package service
+
+import (
+	"github.com/strava/go.serversets"
+	"github.com/stretchr/testify/mock"
+)
+
+type mockRegistrar struct {
+	mock.Mock
+}
+
+func (m *mockRegistrar) RegisterEndpoint(host string, port int, pingFunc func() error) (*serversets.Endpoint, error) {
+	arguments := m.Called(host, port, pingFunc)
+	first, _ := arguments.Get(0).(*serversets.Endpoint)
+	return first, arguments.Error(1)
+}
+
+type mockWatcher struct {
+	mock.Mock
+}
+
+func (m *mockWatcher) Watch() (*serversets.Watch, error) {
+	arguments := m.Called()
+	first, _ := arguments.Get(0).(*serversets.Watch)
+	return first, arguments.Error(1)
+}
+
+type mockAccessor struct {
+	mock.Mock
+}
+
+func (m *mockAccessor) Get(key []byte) (string, error) {
+	arguments := m.Called(key)
+	return arguments.String(0), arguments.Error(1)
+}
+
+type mockAccessorFactory struct {
+	mock.Mock
+}
+
+func (m *mockAccessorFactory) New(endpoints []string) Accessor {
+	arguments := m.Called(endpoints)
+	first, _ := arguments.Get(0).(Accessor)
+	return first
+}

--- a/service/mocks_test.go
+++ b/service/mocks_test.go
@@ -9,14 +9,6 @@ func nilPingFunc(actual func() error) bool {
 	return actual == nil
 }
 
-type mockEndpoint struct {
-	mock.Mock
-}
-
-func (m *mockEndpoint) Close() {
-	m.Called()
-}
-
 type mockRegistrar struct {
 	mock.Mock
 }

--- a/service/mocks_test.go
+++ b/service/mocks_test.go
@@ -29,6 +29,26 @@ func (m *mockWatcher) Watch() (*serversets.Watch, error) {
 	return first, arguments.Error(1)
 }
 
+type mockWatch struct {
+	mock.Mock
+}
+
+func (m *mockWatch) IsClosed() bool {
+	arguments := m.Called()
+	return arguments.Bool(0)
+}
+
+func (m *mockWatch) Endpoints() []string {
+	arguments := m.Called()
+	first, _ := arguments.Get(0).([]string)
+	return first
+}
+
+func (m *mockWatch) Event() <-chan struct{} {
+	arguments := m.Called()
+	return arguments.Get(0).(<-chan struct{})
+}
+
 type mockAccessor struct {
 	mock.Mock
 }

--- a/service/mocks_test.go
+++ b/service/mocks_test.go
@@ -5,6 +5,18 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
+func nilPingFunc(actual func() error) bool {
+	return actual == nil
+}
+
+type mockEndpoint struct {
+	mock.Mock
+}
+
+func (m *mockEndpoint) Close() {
+	m.Called()
+}
+
 type mockRegistrar struct {
 	mock.Mock
 }

--- a/service/options.go
+++ b/service/options.go
@@ -8,10 +8,11 @@ import (
 )
 
 const (
-	DefaultZookeeper   = "localhost:2181"
-	DefaultEnvironment = serversets.Local
-	DefaultServiceName = "test"
-	DefaultVnodeCount  = 10000
+	DefaultZookeeper        = "localhost:2181"
+	DefaultZookeeperTimeout = 5 * time.Second
+	DefaultEnvironment      = serversets.Local
+	DefaultServiceName      = "test"
+	DefaultVnodeCount       = 10000
 )
 
 // Options represents the set of configurable attributes for service discovery and registration
@@ -47,7 +48,7 @@ func (o *Options) zookeeperTimeout() time.Duration {
 		return time.Duration(o.ZookeeperTimeout)
 	}
 
-	return serversets.DefaultZKTimeout
+	return DefaultZookeeperTimeout
 }
 
 func (o *Options) environment() serversets.Environment {

--- a/service/options.go
+++ b/service/options.go
@@ -11,7 +11,7 @@ const (
 	DefaultZookeeper   = "localhost:2181"
 	DefaultEnvironment = serversets.Local
 	DefaultServiceName = "test"
-	DefaultVnodeCount  = 220
+	DefaultVnodeCount  = 10000
 )
 
 // Options represents the set of configurable attributes for service discovery and registration

--- a/service/options.go
+++ b/service/options.go
@@ -1,0 +1,44 @@
+package service
+
+import (
+	"github.com/strava/go.serversets"
+)
+
+const (
+	DefaultZookeeper   = "localhost:2181"
+	DefaultEnvironment = serversets.Local
+	DefaultServiceName = "test"
+)
+
+// Options represents the set of configurable attributes for service discovery and registration
+type Options struct {
+	Zookeepers    []string     `json:"zookeepers"`
+	Environment   string       `json:"environment"`
+	ServiceName   string       `json:"serviceName"`
+	Registrations []string     `json:"registrations,omitempty"`
+	PingFunc      func() error `json:"-"`
+}
+
+func (o *Options) zookeepers() []string {
+	if o != nil && len(o.Zookeepers) > 0 {
+		return o.Zookeepers
+	}
+
+	return []string{DefaultZookeeper}
+}
+
+func (o *Options) environment() serversets.Environment {
+	if o != nil && len(o.Environment) > 0 {
+		return serversets.Environment(o.Environment)
+	}
+
+	return DefaultEnvironment
+}
+
+func (o *Options) serviceName() string {
+	if o != nil && len(o.ServiceName) > 0 {
+		return o.ServiceName
+	}
+
+	return DefaultServiceName
+}

--- a/service/options.go
+++ b/service/options.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"github.com/Comcast/webpa-common/logging"
 	"github.com/strava/go.serversets"
 )
 
@@ -8,15 +9,26 @@ const (
 	DefaultZookeeper   = "localhost:2181"
 	DefaultEnvironment = serversets.Local
 	DefaultServiceName = "test"
+	DefaultVnodeCount  = 220
 )
 
 // Options represents the set of configurable attributes for service discovery and registration
 type Options struct {
-	Zookeepers    []string     `json:"zookeepers"`
-	Environment   string       `json:"environment"`
-	ServiceName   string       `json:"serviceName"`
-	Registrations []string     `json:"registrations,omitempty"`
-	PingFunc      func() error `json:"-"`
+	Logger        logging.Logger `json:"-"`
+	Zookeepers    []string       `json:"zookeepers"`
+	Environment   string         `json:"environment"`
+	ServiceName   string         `json:"serviceName"`
+	Registrations []string       `json:"registrations,omitempty"`
+	VnodeCount    int            `json:"vnodeCount"`
+	PingFunc      func() error   `json:"-"`
+}
+
+func (o *Options) logger() logging.Logger {
+	if o != nil && o.Logger != nil {
+		return o.Logger
+	}
+
+	return logging.DefaultLogger()
 }
 
 func (o *Options) zookeepers() []string {
@@ -41,4 +53,12 @@ func (o *Options) serviceName() string {
 	}
 
 	return DefaultServiceName
+}
+
+func (o *Options) vnodeCount() int {
+	if o != nil && o.VnodeCount > 0 {
+		return o.VnodeCount
+	}
+
+	return DefaultVnodeCount
 }

--- a/service/options.go
+++ b/service/options.go
@@ -8,12 +8,52 @@ import (
 )
 
 const (
+	DefaultScheme           = "http"
+	DefaultHost             = "localhost"
 	DefaultZookeeper        = "localhost:2181"
 	DefaultZookeeperTimeout = 5 * time.Second
 	DefaultEnvironment      = serversets.Local
 	DefaultServiceName      = "test"
 	DefaultVnodeCount       = 10000
 )
+
+var (
+	defaultPorts = map[string]uint16{
+		"http":  80,
+		"https": 443,
+	}
+)
+
+// Registration describes a single endpoint to register.
+type Registration struct {
+	Scheme string `json:"scheme"`
+	Host   string `json:"host"`
+	Port   uint16 `json:"port"`
+}
+
+func (r *Registration) scheme() string {
+	if r != nil && len(r.Scheme) > 0 {
+		return r.Scheme
+	}
+
+	return DefaultScheme
+}
+
+func (r *Registration) host() string {
+	if r != nil && len(r.Host) > 0 {
+		return r.Host
+	}
+
+	return DefaultHost
+}
+
+func (r *Registration) port() uint16 {
+	if r != nil && r.Port > 0 {
+		return r.Port
+	}
+
+	return defaultPorts[r.scheme()]
+}
 
 // Options represents the set of configurable attributes for service discovery and registration
 type Options struct {
@@ -22,7 +62,7 @@ type Options struct {
 	ZookeeperTimeout types.Duration `json:"zookeeperTimeout"`
 	Environment      string         `json:"environment"`
 	ServiceName      string         `json:"serviceName"`
-	Registrations    []string       `json:"registrations,omitempty"`
+	Registrations    []Registration `json:"registrations,omitempty"`
 	VnodeCount       int            `json:"vnodeCount"`
 	PingFunc         func() error   `json:"-"`
 }

--- a/service/options.go
+++ b/service/options.go
@@ -3,19 +3,20 @@ package service
 import (
 	"github.com/Comcast/webpa-common/logging"
 	"github.com/strava/go.serversets"
+	"strings"
 	"time"
 )
 
 const (
-	DefaultScheme           = "http"
-	DefaultHost             = "localhost"
-	DefaultZookeeperServer  = "localhost:2181"
-	DefaultZookeeperTimeout = 5 * time.Second
-	DefaultBaseDirectory    = "/webpa"
-	DefaultMemberPrefix     = "webpa_"
-	DefaultEnvironment      = serversets.Local
-	DefaultServiceName      = "test"
-	DefaultVnodeCount       = 10000
+	DefaultScheme        = "http"
+	DefaultHost          = "localhost"
+	DefaultServer        = "localhost:2181"
+	DefaultTimeout       = 5 * time.Second
+	DefaultBaseDirectory = "/webpa"
+	DefaultMemberPrefix  = "webpa_"
+	DefaultEnvironment   = serversets.Local
+	DefaultServiceName   = "test"
+	DefaultVnodeCount    = 10000
 )
 
 var (
@@ -27,9 +28,17 @@ var (
 
 // Registration describes a single endpoint to register.
 type Registration struct {
+	// Scheme is the scheme portion of the registered URL, e.g. "http" or "https".
+	// Non-HTTP schemes are allowed, but no default ports are set.
 	Scheme string `json:"scheme"`
-	Host   string `json:"host"`
-	Port   uint16 `json:"port"`
+
+	// Host is the FQDN or DNS host name of the registered service.
+	Host string `json:"host"`
+
+	// Port is the IP port of the registered service.  If not set, and if Scheme
+	// is either not set or set to an HTTP scheme, then the Port is set to the default
+	// port when registering.
+	Port uint16 `json:"port"`
 }
 
 func (r *Registration) scheme() string {
@@ -58,16 +67,45 @@ func (r *Registration) port() uint16 {
 
 // Options represents the set of configurable attributes for service discovery and registration
 type Options struct {
-	Logger           logging.Logger `json:"-"`
-	ZookeeperServers []string       `json:"zookeeperServers"`
-	ZookeeperTimeout time.Duration  `json:"zookeeperTimeout"`
-	BaseDirectory    string         `json:"baseDirectory"`
-	MemberPrefix     string         `json:"memberPrefix"`
-	Environment      string         `json:"environment"`
-	ServiceName      string         `json:"serviceName"`
-	Registrations    []Registration `json:"registrations,omitempty"`
-	VnodeCount       uint           `json:"vnodeCount"`
-	PingFunc         func() error   `json:"-"`
+	// Logger is used by any component configured via this Options.  If unset, a default
+	// logger is used.
+	Logger logging.Logger `json:"-"`
+
+	// Connection is the comma-delimited Zookeeper connection string.  Both this and
+	// Servers may be set, and they will be merged together when connecting to Zookeeper.
+	Connection string `json:"connection,omitempty"`
+
+	// Servers is the array of Zookeeper servers.  Both this and Connection may be set,
+	// and they will be merged together when connecting to Zookeeper.
+	Servers []string `json:"servers,omitempty"`
+
+	// Timeout is the Zookeeper connection timeout.
+	Timeout time.Duration `json:"timeout"`
+
+	// BaseDirectory is the base path for all znodes created via this Options.
+	BaseDirectory string `json:"baseDirectory,omitempty"`
+
+	// MemberPrefix is the prefix for ephemeral nodes regstered via this Options.
+	MemberPrefix string `json:"memberPrefix,omitempty"`
+
+	// Environment is the environment component of the ephemeral znode path.
+	Environment string `json:"environment,omitempty"`
+
+	// ServiceName is the name of the service being registered.
+	ServiceName string `json:"serviceName,omitempty"`
+
+	// Registrations holds the slice of information used to register endpoints.  Typically,
+	// this slice will either (1) be empty for an application that only watches for changes,  or (2) have the single
+	// Registration indicating how this service is known.  Multiple registrations, essentially
+	// being aliases for the same application, are supported.
+	Registrations []Registration `json:"registrations,omitempty"`
+
+	// VnodeCount is used to tune the underlying consistent hash algorithm for servers.
+	VnodeCount uint `json:"vnodeCount"`
+
+	// PingFunc is the callback function used to determine if this application is still able
+	// to respond to requests.  This can be nil, and there is no default.
+	PingFunc func() error `json:"-"`
 }
 
 func (o *Options) logger() logging.Logger {
@@ -78,20 +116,34 @@ func (o *Options) logger() logging.Logger {
 	return logging.DefaultLogger()
 }
 
-func (o *Options) zookeeperServers() []string {
-	if o != nil && len(o.ZookeeperServers) > 0 {
-		return o.ZookeeperServers
+func (o *Options) servers() []string {
+	servers := make([]string, 0, 10)
+
+	if o != nil {
+		if len(o.Connection) > 0 {
+			for _, server := range strings.Split(o.Connection, ",") {
+				servers = append(servers, strings.TrimSpace(server))
+			}
+		}
+
+		if len(o.Servers) > 0 {
+			servers = append(servers, o.Servers...)
+		}
 	}
 
-	return []string{DefaultZookeeperServer}
+	if len(servers) == 0 {
+		servers = append(servers, DefaultServer)
+	}
+
+	return servers
 }
 
-func (o *Options) zookeeperTimeout() time.Duration {
-	if o != nil && o.ZookeeperTimeout > 0 {
-		return time.Duration(o.ZookeeperTimeout)
+func (o *Options) timeout() time.Duration {
+	if o != nil && o.Timeout > 0 {
+		return time.Duration(o.Timeout)
 	}
 
-	return DefaultZookeeperTimeout
+	return DefaultTimeout
 }
 
 func (o *Options) baseDirectory() string {

--- a/service/options.go
+++ b/service/options.go
@@ -2,7 +2,9 @@ package service
 
 import (
 	"github.com/Comcast/webpa-common/logging"
+	"github.com/Comcast/webpa-common/types"
 	"github.com/strava/go.serversets"
+	"time"
 )
 
 const (
@@ -14,13 +16,14 @@ const (
 
 // Options represents the set of configurable attributes for service discovery and registration
 type Options struct {
-	Logger        logging.Logger `json:"-"`
-	Zookeepers    []string       `json:"zookeepers"`
-	Environment   string         `json:"environment"`
-	ServiceName   string         `json:"serviceName"`
-	Registrations []string       `json:"registrations,omitempty"`
-	VnodeCount    int            `json:"vnodeCount"`
-	PingFunc      func() error   `json:"-"`
+	Logger           logging.Logger `json:"-"`
+	Zookeepers       []string       `json:"zookeepers"`
+	ZookeeperTimeout types.Duration `json:"zookeeperTimeout"`
+	Environment      string         `json:"environment"`
+	ServiceName      string         `json:"serviceName"`
+	Registrations    []string       `json:"registrations,omitempty"`
+	VnodeCount       int            `json:"vnodeCount"`
+	PingFunc         func() error   `json:"-"`
 }
 
 func (o *Options) logger() logging.Logger {
@@ -37,6 +40,14 @@ func (o *Options) zookeepers() []string {
 	}
 
 	return []string{DefaultZookeeper}
+}
+
+func (o *Options) zookeeperTimeout() time.Duration {
+	if o != nil && o.ZookeeperTimeout > 0 {
+		return time.Duration(o.ZookeeperTimeout)
+	}
+
+	return serversets.DefaultZKTimeout
 }
 
 func (o *Options) environment() serversets.Environment {

--- a/service/options_test.go
+++ b/service/options_test.go
@@ -1,9 +1,80 @@
 package service
 
 import (
+	"errors"
+	"github.com/Comcast/webpa-common/logging"
+	"github.com/strava/go.serversets"
 	"github.com/stretchr/testify/assert"
 	"testing"
+	"time"
 )
+
+func TestRegistrationDefault(t *testing.T) {
+	assert := assert.New(t)
+
+	for _, r := range []*Registration{nil, new(Registration)} {
+		t.Log(r)
+
+		assert.Equal(DefaultScheme, r.scheme())
+		assert.Equal(DefaultHost, r.host())
+		assert.Equal(defaultPorts[DefaultScheme], r.port())
+	}
+}
+
+func TestRegistration(t *testing.T) {
+	assert := assert.New(t)
+	testData := []struct {
+		registration   *Registration
+		expectedScheme string
+		expectedHost   string
+		expectedPort   uint16
+	}{
+		{
+			&Registration{Scheme: "unrecognized", Host: "comcast.net"},
+			"unrecognized",
+			"comcast.net",
+			0,
+		},
+		{
+			&Registration{Scheme: "unrecognized", Host: "comcast.net", Port: 4721},
+			"unrecognized",
+			"comcast.net",
+			4721,
+		},
+		{
+			&Registration{Host: "comcast.net"},
+			"http",
+			"comcast.net",
+			80,
+		},
+		{
+			&Registration{Scheme: "http", Host: "comcast.net"},
+			"http",
+			"comcast.net",
+			80,
+		},
+		{
+			&Registration{Scheme: "https", Host: "comcast.net"},
+			"https",
+			"comcast.net",
+			443,
+		},
+		{
+			&Registration{Scheme: "https", Host: "comcast.net", Port: 8080},
+			"https",
+			"comcast.net",
+			8080,
+		},
+	}
+
+	for _, record := range testData {
+		t.Logf("%v", record)
+
+		assert.Equal(record.expectedScheme, record.registration.scheme())
+		assert.Equal(record.expectedHost, record.registration.host())
+		assert.Equal(record.expectedPort, record.registration.port())
+	}
+}
 
 func TestOptionsDefault(t *testing.T) {
 	assert := assert.New(t)
@@ -12,7 +83,45 @@ func TestOptionsDefault(t *testing.T) {
 		t.Log(o)
 
 		assert.NotNil(o.logger())
-		assert.Equal([]string{DefaultZookeeper}, o.zookeepers())
+		assert.Equal([]string{DefaultZookeeperServer}, o.zookeeperServers())
 		assert.Equal(DefaultZookeeperTimeout, o.zookeeperTimeout())
+		assert.Equal(DefaultBaseDirectory, o.baseDirectory())
+		assert.Equal(DefaultMemberPrefix, o.memberPrefix())
+		assert.Equal(DefaultEnvironment, o.environment())
+		assert.Equal(DefaultServiceName, o.serviceName())
+		assert.Empty(o.registrations())
+		assert.Equal(DefaultVnodeCount, o.vnodeCount())
+		assert.Nil(o.pingFunc())
 	}
+}
+
+func TestOptions(t *testing.T) {
+	assert := assert.New(t)
+	logger := logging.TestLogger(t)
+	expectedError := errors.New("TestOptions expected error")
+	pingFunc := func() error { return expectedError }
+
+	o := Options{
+		Logger:           logger,
+		ZookeeperServers: []string{"node1.comcast.net:2181", "node2.comcast.net:275"},
+		ZookeeperTimeout: 16 * time.Minute,
+		BaseDirectory:    "/testOptions/workspace",
+		MemberPrefix:     "testOptions_",
+		Environment:      "test-options",
+		ServiceName:      "options",
+		Registrations:    []Registration{Registration{}, Registration{"https", "comcast.net", 8080}},
+		VnodeCount:       67912723,
+		PingFunc:         pingFunc,
+	}
+
+	assert.Equal(logger, o.logger())
+	assert.Equal(o.ZookeeperServers, o.zookeeperServers())
+	assert.Equal(o.ZookeeperTimeout, o.zookeeperTimeout())
+	assert.Equal(o.BaseDirectory, o.baseDirectory())
+	assert.Equal(o.MemberPrefix, o.memberPrefix())
+	assert.Equal(serversets.Environment(o.Environment), o.environment())
+	assert.Equal(o.ServiceName, o.serviceName())
+	assert.Equal(o.Registrations, o.registrations())
+	assert.Equal(int(o.VnodeCount), o.vnodeCount())
+	assert.Equal(expectedError, o.pingFunc()())
 }

--- a/service/options_test.go
+++ b/service/options_test.go
@@ -83,8 +83,8 @@ func TestOptionsDefault(t *testing.T) {
 		t.Log(o)
 
 		assert.NotNil(o.logger())
-		assert.Equal([]string{DefaultZookeeperServer}, o.zookeeperServers())
-		assert.Equal(DefaultZookeeperTimeout, o.zookeeperTimeout())
+		assert.Equal([]string{DefaultServer}, o.servers())
+		assert.Equal(DefaultTimeout, o.timeout())
 		assert.Equal(DefaultBaseDirectory, o.baseDirectory())
 		assert.Equal(DefaultMemberPrefix, o.memberPrefix())
 		assert.Equal(DefaultEnvironment, o.environment())
@@ -99,29 +99,81 @@ func TestOptions(t *testing.T) {
 	assert := assert.New(t)
 	logger := logging.TestLogger(t)
 	expectedError := errors.New("TestOptions expected error")
-	pingFunc := func() error { return expectedError }
-
-	o := Options{
-		Logger:           logger,
-		ZookeeperServers: []string{"node1.comcast.net:2181", "node2.comcast.net:275"},
-		ZookeeperTimeout: 16 * time.Minute,
-		BaseDirectory:    "/testOptions/workspace",
-		MemberPrefix:     "testOptions_",
-		Environment:      "test-options",
-		ServiceName:      "options",
-		Registrations:    []Registration{Registration{}, Registration{"https", "comcast.net", 8080}},
-		VnodeCount:       67912723,
-		PingFunc:         pingFunc,
+	testData := []struct {
+		options         *Options
+		expectedServers []string
+		expectedTimeout time.Duration
+	}{
+		{
+			&Options{
+				Logger:        logger,
+				Servers:       []string{"node1.comcast.net:2181", "node2.comcast.net:275"},
+				Timeout:       16 * time.Minute,
+				BaseDirectory: "/testOptions/workspace",
+				MemberPrefix:  "testOptions_",
+				Environment:   "test-options",
+				ServiceName:   "options",
+				Registrations: []Registration{Registration{}, Registration{"https", "comcast.net", 8080}},
+				VnodeCount:    67912723,
+				PingFunc:      nil,
+			},
+			[]string{"node1.comcast.net:2181", "node2.comcast.net:275"},
+			16 * time.Minute,
+		},
+		{
+			&Options{
+				Connection:    "test1.comcast.net:2181",
+				Timeout:       -5 * time.Minute,
+				BaseDirectory: "/testOptions/workspace",
+				MemberPrefix:  "testOptions_",
+				Environment:   "test-options",
+				ServiceName:   "options",
+				VnodeCount:    34572,
+				PingFunc:      func() error { return expectedError },
+			},
+			[]string{"test1.comcast.net:2181"},
+			DefaultTimeout,
+		},
+		{
+			&Options{
+				Connection:    "test1.comcast.net:2181, test2.foobar.com:9999   \t",
+				Servers:       []string{"node1.qbert.net"},
+				Timeout:       7 * time.Hour,
+				BaseDirectory: "/testOptions/workspace",
+				MemberPrefix:  "testOptions_",
+				Environment:   "test-options",
+				ServiceName:   "options",
+				VnodeCount:    34572,
+				PingFunc:      func() error { return expectedError },
+			},
+			[]string{"test1.comcast.net:2181", "test2.foobar.com:9999", "node1.qbert.net"},
+			7 * time.Hour,
+		},
 	}
 
-	assert.Equal(logger, o.logger())
-	assert.Equal(o.ZookeeperServers, o.zookeeperServers())
-	assert.Equal(o.ZookeeperTimeout, o.zookeeperTimeout())
-	assert.Equal(o.BaseDirectory, o.baseDirectory())
-	assert.Equal(o.MemberPrefix, o.memberPrefix())
-	assert.Equal(serversets.Environment(o.Environment), o.environment())
-	assert.Equal(o.ServiceName, o.serviceName())
-	assert.Equal(o.Registrations, o.registrations())
-	assert.Equal(int(o.VnodeCount), o.vnodeCount())
-	assert.Equal(expectedError, o.pingFunc()())
+	for _, record := range testData {
+		t.Logf("%v", record)
+		options := record.options
+
+		if options.Logger != nil {
+			assert.Equal(options.Logger, options.logger())
+		} else {
+			assert.NotNil(options.logger())
+		}
+
+		assert.Equal(record.expectedServers, options.servers())
+		assert.Equal(record.expectedTimeout, options.timeout())
+		assert.Equal(options.BaseDirectory, options.baseDirectory())
+		assert.Equal(options.MemberPrefix, options.memberPrefix())
+		assert.Equal(serversets.Environment(options.Environment), options.environment())
+		assert.Equal(options.ServiceName, options.serviceName())
+		assert.Equal(options.Registrations, options.registrations())
+		assert.Equal(int(options.VnodeCount), options.vnodeCount())
+
+		if options.PingFunc != nil {
+			assert.Equal(expectedError, options.pingFunc()())
+		} else {
+			assert.Nil(options.pingFunc())
+		}
+	}
 }

--- a/service/options_test.go
+++ b/service/options_test.go
@@ -1,0 +1,18 @@
+package service
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestOptionsDefault(t *testing.T) {
+	assert := assert.New(t)
+
+	for _, o := range []*Options{nil, new(Options)} {
+		t.Log(o)
+
+		assert.NotNil(o.logger())
+		assert.Equal([]string{DefaultZookeeper}, o.zookeepers())
+		assert.Equal(DefaultZookeeperTimeout, o.zookeeperTimeout())
+	}
+}

--- a/service/registrarWatcher.go
+++ b/service/registrarWatcher.go
@@ -60,8 +60,12 @@ func RegisterOne(registrar Registrar, registration Registration, pingFunc func()
 func RegisterAll(registrar Registrar, o *Options) ([]*serversets.Endpoint, error) {
 	registrations := o.registrations()
 	if len(registrations) > 0 {
-		logger := o.logger()
-		endpoints := make([]*serversets.Endpoint, 0, len(registrations))
+		var (
+			logger    = o.logger()
+			pingFunc  = o.pingFunc()
+			endpoints = make([]*serversets.Endpoint, 0, len(registrations))
+		)
+
 		for _, registration := range registrations {
 			logger.Info(
 				"Registering endpoint: scheme=%s, host=%s, port=%d",
@@ -70,7 +74,7 @@ func RegisterAll(registrar Registrar, o *Options) ([]*serversets.Endpoint, error
 				registration.Port,
 			)
 
-			endpoint, err := RegisterOne(registrar, registration, o.pingFunc())
+			endpoint, err := RegisterOne(registrar, registration, pingFunc)
 			if err != nil {
 				return endpoints, err
 			}

--- a/service/registrarWatcher.go
+++ b/service/registrarWatcher.go
@@ -1,0 +1,91 @@
+package service
+
+import (
+	"github.com/strava/go.serversets"
+	"strconv"
+	"strings"
+)
+
+// Registrar is the interface which is used to register endpoints.
+// *serversets.ServerSet implements this interface.
+type Registrar interface {
+	RegisterEndpoint(string, int, func() error) (*serversets.Endpoint, error)
+}
+
+// Watcher is the interface used to observe changes to the set of endpoints.
+// *serversets.ServerSet implements this interface.
+type Watcher interface {
+	Watch() (*serversets.Watch, error)
+}
+
+// RegistrarWatcher is simply the union of the serversets interfaces in this package.
+type RegistrarWatcher interface {
+	Registrar
+	Watcher
+}
+
+// ParseRegistration separates a string value into a host and a port.  This function assumes
+// that value will have a format like "host:port".  If there is no semicolon, or if what comes
+// after the last semicolon is not an integer, this function returns the value as the host
+// and zero (0) for the port.
+func ParseRegistration(value string) (string, int, error) {
+	position := strings.LastIndex(value, ":")
+	if position >= 0 {
+		port, err := strconv.Atoi(value[position+1:])
+		if err == nil {
+			return value[0:position], port, nil
+		}
+	}
+
+	return value, 0, nil
+}
+
+// NewRegistrarWatcher produces a serversets.ServerSet using a supplied set of options
+func NewRegistrarWatcher(o *Options) RegistrarWatcher {
+	return serversets.New(
+		o.environment(),
+		o.serviceName(),
+		o.zookeepers(),
+	)
+}
+
+// RegisterEndpoints registers all host:port strings found in o.Registrations.  This
+// function returns a nil slice if o == nil or if o has no registrations.  If any errors
+// occur, this function returns a partial slice of endpoints that it could successfully create.
+func RegisterEndpoints(o *Options, registrar Registrar) ([]*serversets.Endpoint, error) {
+	if o != nil && len(o.Registrations) > 0 {
+		var (
+			err               error
+			registrationCount = len(o.Registrations)
+			hosts             = make([]string, registrationCount)
+			ports             = make([]int, registrationCount)
+			endpoint          *serversets.Endpoint
+		)
+
+		for index, registration := range o.Registrations {
+			hosts[index], ports[index], err = ParseRegistration(registration)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		endpoints := make([]*serversets.Endpoint, 0, registrationCount)
+		for index := 0; index < registrationCount; index++ {
+			endpoint, err = registrar.RegisterEndpoint(
+				hosts[index],
+				ports[index],
+				o.PingFunc,
+			)
+
+			if err != nil {
+				return nil, err
+			}
+
+			endpoints = append(endpoints, endpoint)
+		}
+
+		return endpoints, nil
+	}
+
+	return nil, nil
+}

--- a/service/registrarWatcher.go
+++ b/service/registrarWatcher.go
@@ -42,10 +42,10 @@ func NewRegistrarWatcher(o *Options) RegistrarWatcher {
 	serverSet := serversets.New(
 		o.environment(),
 		o.serviceName(),
-		o.zookeeperServers(),
+		o.servers(),
 	)
 
-	serverSet.ZKTimeout = o.zookeeperTimeout()
+	serverSet.ZKTimeout = o.timeout()
 	return serverSet
 }
 

--- a/service/registrarWatcher.go
+++ b/service/registrarWatcher.go
@@ -6,6 +6,14 @@ import (
 	"strings"
 )
 
+// Endpoint is the local interface with *serversets.Endpoint implements.
+// The only thing you can do with an endpoint is close it.
+type Endpoint interface {
+	// Close closes the endpoint and blocks until the underlying Zookeeper connection
+	// is closed.  Note that this Close() method does not return an error, unlike io.Closer.
+	Close()
+}
+
 // Registrar is the interface which is used to register endpoints.
 // *serversets.ServerSet implements this interface.
 type Registrar interface {
@@ -22,14 +30,6 @@ type Watcher interface {
 type RegistrarWatcher interface {
 	Registrar
 	Watcher
-}
-
-// Endpoint is the local interface with *serversets.Endpoint implements.
-// The only thing you can do with an endpoint is close it.
-type Endpoint interface {
-	// Close closes the endpoint and blocks until the underlying Zookeeper connection
-	// is closed.  Note that this Close() method does not return an error, unlike io.Closer.
-	Close()
 }
 
 // ParseRegistration separates a string value into a host and a port.  This function assumes

--- a/service/registrarWatcher_test.go
+++ b/service/registrarWatcher_test.go
@@ -73,7 +73,7 @@ func TestRegisterOneSuccessAndNilPingFunc(t *testing.T) {
 			Return(expectedEndpoint, nil).
 			Once()
 
-		actualEndpoint, err := RegisterOne(record.registration, nil, mockRegistrar)
+		actualEndpoint, err := RegisterOne(mockRegistrar, record.registration, nil)
 		assert.Equal(expectedEndpoint, actualEndpoint)
 		assert.NoError(err)
 

--- a/service/registrarWatcher_test.go
+++ b/service/registrarWatcher_test.go
@@ -1,0 +1,42 @@
+package service
+
+import (
+	"github.com/strava/go.serversets"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"testing"
+)
+
+var registrationTestData = []struct {
+	registration Registration
+	expectedHost string
+	expectedPort int
+}{
+	{
+		Registration{},
+		"http://localhost",
+		80,
+	},
+}
+
+func TestRegisterWithSuccessAndNilPingFunc(t *testing.T) {
+	assert := assert.New(t)
+
+	for _, record := range registrationTestData {
+		t.Logf("%v", record)
+		assert.True(true)
+
+		expectedEndpoint := new(serversets.Endpoint)
+		mockRegistrar := new(mockRegistrar)
+		mockRegistrar.
+			On("RegisterEndpoint", record.expectedHost, record.expectedPort, mock.AnythingOfType("func() error")).
+			Return(expectedEndpoint, nil).
+			Once()
+
+		actualEndpoint, err := RegisterWith(record.registration, nil, mockRegistrar)
+		assert.Equal(expectedEndpoint, actualEndpoint)
+		assert.NoError(err)
+
+		mockRegistrar.AssertExpectations(t)
+	}
+}

--- a/service/registrarWatcher_test.go
+++ b/service/registrarWatcher_test.go
@@ -42,8 +42,8 @@ func TestNewRegistrarWatcher(t *testing.T) {
 
 		assert.Equal(o.baseDirectory(), serversets.BaseDirectory)
 		assert.Equal(o.memberPrefix(), serversets.MemberPrefix)
-		assert.Equal(o.zookeeperServers(), serverSet.ZookeeperServers())
-		assert.Equal(o.zookeeperTimeout(), serverSet.ZKTimeout)
+		assert.Equal(o.servers(), serverSet.ZookeeperServers())
+		assert.Equal(o.timeout(), serverSet.ZKTimeout)
 	}
 }
 

--- a/service/registrarWatcher_test.go
+++ b/service/registrarWatcher_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"errors"
 	"github.com/strava/go.serversets"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -47,35 +48,234 @@ func TestNewRegistrarWatcher(t *testing.T) {
 	}
 }
 
-var registrationTestData = []struct {
-	registration Registration
-	expectedHost string
-	expectedPort int
-}{
-	{
-		Registration{},
-		"http://localhost",
-		80,
-	},
+var (
+	singleRegistration = Registration{
+		Scheme: "https",
+		Host:   "foobar123.webpa.comcast.net",
+		Port:   8080,
+	}
+)
+
+const (
+	expectedRegistrationHost = "https://foobar123.webpa.comcast.net"
+	expectedRegistrationPort = 8080
+)
+
+func TestRegisterOneSuccessWithoutPingFunction(t *testing.T) {
+	assert := assert.New(t)
+	expectedEndpoint := new(serversets.Endpoint)
+	mockRegistrar := new(mockRegistrar)
+	mockRegistrar.
+		On("RegisterEndpoint", expectedRegistrationHost, expectedRegistrationPort, mock.AnythingOfType("func() error")).
+		Return(expectedEndpoint, nil).
+		Once()
+
+	actualEndpoint, err := RegisterOne(mockRegistrar, singleRegistration, nil)
+	assert.Equal(expectedEndpoint, actualEndpoint)
+	assert.NoError(err)
+
+	mockRegistrar.AssertExpectations(t)
 }
 
-func TestRegisterOneSuccessAndNilPingFunc(t *testing.T) {
+func TestRegisterOneFailureWithoutPingFunction(t *testing.T) {
 	assert := assert.New(t)
+	expectedRegisterError := errors.New("expected register error")
+	expectedEndpoint := new(serversets.Endpoint)
+	mockRegistrar := new(mockRegistrar)
+	mockRegistrar.
+		On("RegisterEndpoint", expectedRegistrationHost, expectedRegistrationPort, mock.AnythingOfType("func() error")).
+		Return(expectedEndpoint, expectedRegisterError).
+		Once()
 
-	for _, record := range registrationTestData {
-		t.Logf("%v", record)
-		assert.True(true)
+	actualEndpoint, err := RegisterOne(mockRegistrar, singleRegistration, nil)
+	assert.Equal(expectedEndpoint, actualEndpoint)
+	assert.Equal(expectedRegisterError, err)
 
-		expectedEndpoint := new(serversets.Endpoint)
+	mockRegistrar.AssertExpectations(t)
+}
+
+func TestRegisterOneSuccessWithPingFunction(t *testing.T) {
+	assert := assert.New(t)
+	expectedPingError := errors.New("expected ping error")
+	expectedEndpoint := new(serversets.Endpoint)
+	mockRegistrar := new(mockRegistrar)
+	mockRegistrar.
+		On("RegisterEndpoint", expectedRegistrationHost, expectedRegistrationPort, mock.AnythingOfType("func() error")).
+		Run(func(arguments mock.Arguments) {
+			assert.Equal(expectedPingError, arguments.Get(2).(func() error)())
+		}).
+		Return(expectedEndpoint, nil).
+		Once()
+
+	actualEndpoint, err := RegisterOne(mockRegistrar, singleRegistration, func() error { return expectedPingError })
+	assert.Equal(expectedEndpoint, actualEndpoint)
+	assert.NoError(err)
+
+	mockRegistrar.AssertExpectations(t)
+}
+
+func TestRegisterOneFailureWithPingFunction(t *testing.T) {
+	assert := assert.New(t)
+	expectedRegisterError := errors.New("expected register error")
+	expectedPingError := errors.New("expected ping error")
+	expectedEndpoint := new(serversets.Endpoint)
+	mockRegistrar := new(mockRegistrar)
+	mockRegistrar.
+		On("RegisterEndpoint", expectedRegistrationHost, expectedRegistrationPort, mock.AnythingOfType("func() error")).
+		Run(func(arguments mock.Arguments) {
+			assert.Equal(expectedPingError, arguments.Get(2).(func() error)())
+		}).
+		Return(expectedEndpoint, expectedRegisterError).
+		Once()
+
+	actualEndpoint, err := RegisterOne(mockRegistrar, singleRegistration, func() error { return expectedPingError })
+	assert.Equal(expectedEndpoint, actualEndpoint)
+	assert.Equal(err, expectedRegisterError)
+
+	mockRegistrar.AssertExpectations(t)
+}
+
+func TestRegisterOneBadPort(t *testing.T) {
+	assert := assert.New(t)
+	badPortRegistration := Registration{
+		Scheme: "unrecognized",
+		Host:   "foobar.com",
+	}
+
+	mockRegistrar := new(mockRegistrar)
+
+	actualEndpoint, err := RegisterOne(mockRegistrar, badPortRegistration, nil)
+	assert.Nil(actualEndpoint)
+	assert.Error(err)
+
+	mockRegistrar.AssertExpectations(t)
+}
+
+func TestRegisterAllNoRegistrations(t *testing.T) {
+	assert := assert.New(t)
+	for _, o := range []*Options{nil, new(Options)} {
+		t.Log(o)
+
 		mockRegistrar := new(mockRegistrar)
-		mockRegistrar.
-			On("RegisterEndpoint", record.expectedHost, record.expectedPort, mock.AnythingOfType("func() error")).
-			Return(expectedEndpoint, nil).
-			Once()
 
-		actualEndpoint, err := RegisterOne(mockRegistrar, record.registration, nil)
-		assert.Equal(expectedEndpoint, actualEndpoint)
+		actualEndpoints, err := RegisterAll(mockRegistrar, o)
+		assert.Empty(actualEndpoints)
 		assert.NoError(err)
+
+		mockRegistrar.AssertExpectations(t)
+	}
+}
+
+func TestRegisterAll(t *testing.T) {
+	assert := assert.New(t)
+	testData := []struct {
+		options           *Options
+		expectedHosts     []string
+		expectedPorts     []int
+		expectedEndpoints []*serversets.Endpoint
+		expectsError      bool
+	}{
+		{
+			options: &Options{
+				Registrations: []Registration{
+					Registration{Scheme: "https", Host: "node1.comcast.net", Port: 1467},
+				},
+			},
+			expectedHosts:     []string{"https://node1.comcast.net"},
+			expectedPorts:     []int{1467},
+			expectedEndpoints: []*serversets.Endpoint{new(serversets.Endpoint)},
+			expectsError:      false,
+		},
+		{
+			options: &Options{
+				Registrations: []Registration{
+					Registration{Scheme: "unregonized", Host: "this.should.not.be.registered.com"},
+				},
+			},
+			expectedHosts:     []string{},
+			expectedPorts:     []int{},
+			expectedEndpoints: []*serversets.Endpoint{},
+			expectsError:      true,
+		},
+		{
+			options: &Options{
+				Registrations: []Registration{
+					Registration{Host: "node17.foobar.com"},
+					Registration{Scheme: "https", Host: "node1.comcast.net", Port: 1467},
+				},
+			},
+			expectedHosts:     []string{"http://node17.foobar.com", "https://node1.comcast.net"},
+			expectedPorts:     []int{80, 1467},
+			expectedEndpoints: []*serversets.Endpoint{new(serversets.Endpoint), new(serversets.Endpoint)},
+			expectsError:      false,
+		},
+		{
+			options: &Options{
+				Registrations: []Registration{
+					Registration{Scheme: "unregonized", Host: "this.should.not.be.registered.com"},
+					Registration{Host: "node17.foobar.com"},
+					Registration{Scheme: "https", Host: "node1.comcast.net", Port: 1467},
+				},
+			},
+			expectedHosts:     []string{},
+			expectedPorts:     []int{},
+			expectedEndpoints: []*serversets.Endpoint{},
+			expectsError:      true,
+		},
+		{
+			options: &Options{
+				Registrations: []Registration{
+					Registration{Host: "node17.foobar.com"},
+					Registration{Scheme: "unregonized", Host: "this.should.not.be.registered.com"},
+					Registration{Scheme: "https", Host: "node1.comcast.net", Port: 1467},
+				},
+			},
+			expectedHosts:     []string{"http://node17.foobar.com"},
+			expectedPorts:     []int{80},
+			expectedEndpoints: []*serversets.Endpoint{new(serversets.Endpoint)},
+			expectsError:      true,
+		},
+		{
+			options: &Options{
+				Registrations: []Registration{
+					Registration{Host: "node17.foobar.com"},
+					Registration{Scheme: "https", Host: "node1.comcast.net", Port: 1467},
+					Registration{Scheme: "unregonized", Host: "this.should.not.be.registered.com"},
+				},
+			},
+			expectedHosts:     []string{"http://node17.foobar.com", "https://node1.comcast.net"},
+			expectedPorts:     []int{80, 1467},
+			expectedEndpoints: []*serversets.Endpoint{new(serversets.Endpoint), new(serversets.Endpoint)},
+			expectsError:      true,
+		},
+		{
+			options: &Options{
+				Registrations: []Registration{
+					Registration{Host: "node17.foobar.com"},
+					Registration{Scheme: "https", Host: "node1.comcast.net", Port: 1467},
+					Registration{Scheme: "http", Host: "gronk.something.tv", Port: 610},
+				},
+			},
+			expectedHosts:     []string{"http://node17.foobar.com", "https://node1.comcast.net", "http://gronk.something.tv"},
+			expectedPorts:     []int{80, 1467, 610},
+			expectedEndpoints: []*serversets.Endpoint{new(serversets.Endpoint), new(serversets.Endpoint), new(serversets.Endpoint)},
+			expectsError:      false,
+		},
+	}
+
+	for _, record := range testData {
+		t.Logf("%v", record)
+
+		mockRegistrar := new(mockRegistrar)
+		for index, expectedHost := range record.expectedHosts {
+			mockRegistrar.On(
+				"RegisterEndpoint", expectedHost, record.expectedPorts[index], mock.AnythingOfType("func() error"),
+			).Return(record.expectedEndpoints[index], nil).Once()
+		}
+
+		actualEndpoints, err := RegisterAll(mockRegistrar, record.options)
+		assert.Equal(record.expectedEndpoints, actualEndpoints)
+		assert.Equal(record.expectsError, err != nil)
 
 		mockRegistrar.AssertExpectations(t)
 	}

--- a/service/subscribe.go
+++ b/service/subscribe.go
@@ -1,0 +1,99 @@
+package service
+
+import (
+	"github.com/strava/go.serversets"
+	"sync/atomic"
+)
+
+// Watch is the subset of methods required by this package that *serversets.Watch implements
+type Watch interface {
+	IsClosed() bool
+	Event() <-chan struct{}
+	Endpoints() []string
+}
+
+var _ Watch = (*serversets.Watch)(nil)
+
+// Subscription represents something that is receiving events from a watch and updating
+// its state.
+type Subscription interface {
+	// Cancel removes this subscription from the underlying infrastructure.  No further
+	// updates will occur, but this subscription's state will still be usable.
+	// This method is idempotent.
+	Cancel()
+}
+
+// AccessorSubscription represents an Accessor whose state changes as the result
+// of events via a subscription.
+type AccessorSubscription interface {
+	Accessor
+	Subscription
+}
+
+// accessorSubscription is the internal implementation of AccessorSubscription
+type accessorSubscription struct {
+	factory AccessorFactory
+	value   atomic.Value
+	cancel  chan struct{}
+}
+
+func (a *accessorSubscription) Cancel() {
+	defer func() {
+		recover()
+	}()
+
+	close(a.cancel)
+}
+
+func (a *accessorSubscription) Get(key []byte) (string, error) {
+	return a.value.Load().(Accessor).Get(key)
+}
+
+func (a *accessorSubscription) update(endpoints []string) {
+	a.value.Store(a.factory.New(endpoints))
+}
+
+// NewAccessorSubscription subscribes to a watch and updates an atomic Accessor in response
+// to updated service endpoints.  The returned object is fully initialized and can be used
+// to access endpoints immediately.  In addition, the subscription can be cancelled at any time.
+// If the underlying service discovery infrastructure is shutdown, the subscription will no
+// longer receive updates but can continue to be used in its stale state.
+func NewAccessorSubscription(o *Options, watch Watch, factory AccessorFactory) AccessorSubscription {
+	logger := o.logger()
+	if factory == nil {
+		factory = NewAccessorFactory(o)
+	}
+
+	subscription := &accessorSubscription{
+		factory: factory,
+		cancel:  make(chan struct{}),
+	}
+
+	// load the initial accessor
+	initialEndpoints := watch.Endpoints()
+	logger.Info("Initial discovered endpoints: %s", initialEndpoints)
+	subscription.update(initialEndpoints)
+
+	// spawn a goroutine that updates the subscription in response
+	// to watch events.
+	go func() {
+		for {
+			select {
+			case <-subscription.cancel:
+				logger.Info("Subscription cancelled")
+				return
+			case <-watch.Event():
+				if watch.IsClosed() {
+					logger.Info("Subscription ending due to watch being closed")
+					return
+				}
+
+				updatedEndpoints := watch.Endpoints()
+				logger.Info("Updated endpoints: %s", updatedEndpoints)
+				subscription.update(updatedEndpoints)
+			}
+		}
+	}()
+
+	return subscription
+}

--- a/service/subscribe_test.go
+++ b/service/subscribe_test.go
@@ -1,0 +1,258 @@
+package service
+
+import (
+	"github.com/Comcast/webpa-common/logging"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"sync"
+	"testing"
+)
+
+func TestSubscribeEndWhenWatchClosed(t *testing.T) {
+	assert := assert.New(t)
+	logger := logging.TestLogger(t)
+
+	expectedUpdates := [][]string{
+		[]string{"updated1"},
+		[]string{"updated2", "updated3"},
+	}
+
+	subscriptionCounter := new(sync.WaitGroup)
+	subscriptionCounter.Add(len(expectedUpdates))
+	actualUpdates := make(chan []string, len(expectedUpdates))
+	subscription := func(update []string) {
+		logger.Info("Test subscription called: %v", update)
+		defer subscriptionCounter.Done()
+
+		select {
+		case actualUpdates <- update:
+		default:
+			assert.Fail("Subscription was called too many times")
+		}
+	}
+
+	var (
+		watchEvent                        = make(chan struct{})
+		receiveWatchEvent <-chan struct{} = watchEvent
+		mockWatch                         = new(mockWatch)
+	)
+
+	// first update
+	mockWatch.On("Event").Return(receiveWatchEvent).Once()
+	mockWatch.On("IsClosed").Return(false).Once()
+	mockWatch.On("Endpoints").Return(expectedUpdates[0]).Once()
+
+	// second update
+	mockWatch.On("Event").Return(receiveWatchEvent).Once()
+	mockWatch.On("IsClosed").Return(false).Once()
+	mockWatch.On("Endpoints").Return(expectedUpdates[1]).Once()
+
+	// watch is closed
+	closeWait := new(sync.WaitGroup)
+	closeWait.Add(1)
+	mockWatch.On("Event").Return(receiveWatchEvent).Once()
+	mockWatch.On("IsClosed").Run(func(mock.Arguments) { closeWait.Done() }).Return(true).Once()
+
+	logger.Info("Invoking subscribe, expecting updates: %v\n", expectedUpdates)
+	cancelFunc := Subscribe(mockWatch, logger, subscription)
+	if !assert.NotNil(cancelFunc) {
+		close(watchEvent)
+		return
+	}
+
+	watchEvent <- struct{}{}
+	watchEvent <- struct{}{}
+	subscriptionCounter.Wait()
+
+	// simulate a watch event closure ...
+	// need to wait, to ensure the other goroutine is finished before
+	// we assert expectations
+	watchEvent <- struct{}{}
+	closeWait.Wait()
+
+	close(actualUpdates)
+	position := 0
+	for update := range actualUpdates {
+		assert.Equal(expectedUpdates[position], update)
+		position++
+	}
+
+	mockWatch.AssertExpectations(t)
+}
+
+func TestSubscribeEndWhenCancelled(t *testing.T) {
+	assert := assert.New(t)
+	logger := logging.TestLogger(t)
+
+	expectedUpdates := [][]string{
+		[]string{"updated1"},
+		[]string{"updated2", "updated3"},
+	}
+
+	subscriptionCounter := new(sync.WaitGroup)
+	subscriptionCounter.Add(len(expectedUpdates))
+	actualUpdates := make(chan []string, len(expectedUpdates))
+	subscription := func(update []string) {
+		logger.Info("Test subscription called: %v", update)
+		defer subscriptionCounter.Done()
+
+		select {
+		case actualUpdates <- update:
+		default:
+			assert.Fail("Subscription was called too many times")
+		}
+	}
+
+	var (
+		watchEvent                        = make(chan struct{})
+		receiveWatchEvent <-chan struct{} = watchEvent
+		mockWatch                         = new(mockWatch)
+	)
+
+	// first update
+	mockWatch.On("Event").Return(receiveWatchEvent).Once()
+	mockWatch.On("IsClosed").Return(false).Once()
+	mockWatch.On("Endpoints").Return(expectedUpdates[0]).Once()
+
+	// second update
+	mockWatch.On("Event").Return(receiveWatchEvent).Once()
+	mockWatch.On("IsClosed").Return(false).Once()
+	mockWatch.On("Endpoints").Return(expectedUpdates[1]).Once()
+
+	// watch is cancelled
+	mockWatch.On("Event").Return(receiveWatchEvent).Once()
+
+	logger.Info("Invoking subscribe, expecting updates: %v\n", expectedUpdates)
+	cancelFunc := Subscribe(mockWatch, logger, subscription)
+	if !assert.NotNil(cancelFunc) {
+		close(watchEvent)
+		return
+	}
+
+	watchEvent <- struct{}{}
+	watchEvent <- struct{}{}
+	subscriptionCounter.Wait()
+	cancelFunc()
+
+	// the cancel function should be idempotent
+	cancelFunc()
+
+	close(actualUpdates)
+	position := 0
+	for update := range actualUpdates {
+		assert.Equal(expectedUpdates[position], update)
+		position++
+	}
+
+	mockWatch.AssertExpectations(t)
+}
+
+func TestSubscribeEndWhenSubscriptionPanics(t *testing.T) {
+	assert := assert.New(t)
+
+	expectedUpdate := []string{"update1", "update2"}
+	subscriptionCounter := new(sync.WaitGroup)
+	subscriptionCounter.Add(1)
+	badSubscription := func(actualUpdate []string) {
+		defer subscriptionCounter.Done()
+		assert.Equal(expectedUpdate, actualUpdate)
+		panic("Expected panic from bad subscription")
+	}
+
+	var (
+		watchEvent                        = make(chan struct{})
+		receiveWatchEvent <-chan struct{} = watchEvent
+		mockWatch                         = new(mockWatch)
+	)
+
+	// the only update that will be attempted, as the subscription will panic
+	mockWatch.On("Event").Return(receiveWatchEvent).Once()
+	mockWatch.On("IsClosed").Return(false).Once()
+	mockWatch.On("Endpoints").Return(expectedUpdate).Once()
+
+	cancelFunc := Subscribe(mockWatch, nil, badSubscription)
+	if !assert.NotNil(cancelFunc) {
+		return
+	}
+
+	watchEvent <- struct{}{}
+	subscriptionCounter.Wait()
+
+	// cancelling any number of times after a panic should be idempotent
+	cancelFunc()
+	cancelFunc()
+
+	mockWatch.AssertExpectations(t)
+}
+
+func TestAccessorSubscription(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	key := []byte("does not matter")
+	expectedEndpoints := [][]string{
+		[]string{"initial"},
+		[]string{"update1"},
+		[]string{"update2"},
+	}
+
+	var (
+		watchEvent                        = make(chan struct{})
+		receiveWatchEvent <-chan struct{} = watchEvent
+		mockWatch                         = new(mockWatch)
+	)
+
+	// initializing the accessor subscription itself
+	mockWatch.On("Endpoints").Return(expectedEndpoints[0]).Once()
+
+	// first update
+	mockWatch.On("Event").Return(receiveWatchEvent).Once()
+	mockWatch.On("IsClosed").Return(false).Once()
+	mockWatch.On("Endpoints").Return(expectedEndpoints[1]).Once()
+
+	// second update
+	secondUpdate := new(sync.WaitGroup)
+	secondUpdate.Add(1)
+	mockWatch.On("Event").Run(func(mock.Arguments) { secondUpdate.Done() }).Return(receiveWatchEvent).Once()
+	mockWatch.On("IsClosed").Return(false).Once()
+	mockWatch.On("Endpoints").Return(expectedEndpoints[2]).Once()
+
+	// watch is cancelled
+	finalUpdate := new(sync.WaitGroup)
+	finalUpdate.Add(1)
+	mockWatch.On("Event").Run(func(mock.Arguments) { finalUpdate.Done() }).Return(receiveWatchEvent).Once()
+
+	accessorSubscription := NewAccessorSubscription(mockWatch, nil, nil)
+	require.NotNil(accessorSubscription)
+
+	hashedEndpoint, err := accessorSubscription.Get(key)
+	assert.Equal(expectedEndpoints[0][0], hashedEndpoint)
+	assert.NoError(err)
+
+	// after the second update starts, the changes from the first should be visible
+	watchEvent <- struct{}{}
+	secondUpdate.Wait()
+	hashedEndpoint, err = accessorSubscription.Get(key)
+	assert.Equal(expectedEndpoints[1][0], hashedEndpoint)
+	assert.NoError(err)
+
+	watchEvent <- struct{}{}
+	finalUpdate.Wait()
+	hashedEndpoint, err = accessorSubscription.Get(key)
+	assert.Equal(expectedEndpoints[2][0], hashedEndpoint)
+	assert.NoError(err)
+
+	accessorSubscription.Cancel()
+	hashedEndpoint, err = accessorSubscription.Get(key)
+	assert.Equal(expectedEndpoints[2][0], hashedEndpoint)
+	assert.NoError(err)
+
+	// Cancel should be idempotent
+	accessorSubscription.Cancel()
+	hashedEndpoint, err = accessorSubscription.Get(key)
+	assert.Equal(expectedEndpoints[2][0], hashedEndpoint)
+	assert.NoError(err)
+
+	mockWatch.AssertExpectations(t)
+}


### PR DESCRIPTION
This will completely replace the golang Curator port (foursquare.go).

Typical usage:
```go
options := /* loaded from someplace external */
registrar := NewRegistrarWatcher(options)

// register this application (e.g. talaria)
if _, err := RegisterAll(registrar, options); err != nil {
    fmt.Fprintf(os.Stderr, "%s", err)
    os.Exit(1)
}

// obtain an asynchronously updated service accessor (petasos)
accessor := NewAccessorSubscription(registrar, nil, options)
server := accessor.Get(deviceID.Bytes())

// take some action when services are updated (talaria, to rehash)
watch, err := registrar.Watch()
if err != nil {
    fmt.Fprintf(os.Stderr, "%s", err)
    os.Exit(1)
}

cancel := Subscribe(watch, options.logger(), func(endpoints []string) {
    // rehash or commit other mayhem
})

// perhaps in response to SIGHUP:
cancel()
```
