### PR TITLE
Feature/support hijacking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go: 
-    - 1.7.3
+    - 1.8.3
 
 before_install:
     - sudo pip install --user codecov

--- a/health/mocks_test.go
+++ b/health/mocks_test.go
@@ -1,8 +1,11 @@
 package health
 
 import (
-	"github.com/stretchr/testify/mock"
+	"bufio"
+	"net"
 	"net/http"
+
+	"github.com/stretchr/testify/mock"
 )
 
 type mockHandler struct {
@@ -13,6 +16,7 @@ func (m *mockHandler) ServeHTTP(response http.ResponseWriter, request *http.Requ
 	m.Called(response, request)
 }
 
+// mockResponseWriter is a type that only mocks http.ResponseWriter
 type mockResponseWriter struct {
 	mock.Mock
 }
@@ -28,4 +32,46 @@ func (m *mockResponseWriter) Write(data []byte) (int, error) {
 
 func (m *mockResponseWriter) WriteHeader(statusCode int) {
 	m.Called(statusCode)
+}
+
+// mockResponseWriterFull is a type that not only mocks http.ResponseWriter but also
+// mocks http.CloseNotifier, http.Hijacker, http.Pusher, and http.Flusher.
+type mockResponseWriterFull struct {
+	mock.Mock
+}
+
+func (m *mockResponseWriterFull) Header() http.Header {
+	return m.Called().Get(0).(http.Header)
+}
+
+func (m *mockResponseWriterFull) Write(data []byte) (int, error) {
+	arguments := m.Called(data)
+	return arguments.Int(0), arguments.Error(1)
+}
+
+func (m *mockResponseWriterFull) WriteHeader(statusCode int) {
+	m.Called(statusCode)
+}
+
+func (m *mockResponseWriterFull) CloseNotify() <-chan bool {
+	first, _ := m.Called().Get(0).(<-chan bool)
+	return first
+}
+
+func (m *mockResponseWriterFull) Flush() {
+	m.Called()
+}
+
+func (m *mockResponseWriterFull) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	var (
+		arguments = m.Called()
+		first, _  = arguments.Get(0).(net.Conn)
+		second, _ = arguments.Get(1).(*bufio.ReadWriter)
+	)
+
+	return first, second, arguments.Error(2)
+}
+
+func (m *mockResponseWriterFull) Push(target string, opts *http.PushOptions) error {
+	return m.Called(target, opts).Error(0)
 }

--- a/health/responseWriter.go
+++ b/health/responseWriter.go
@@ -1,6 +1,9 @@
 package health
 
 import (
+	"bufio"
+	"errors"
+	"net"
 	"net/http"
 )
 
@@ -25,4 +28,14 @@ func (r *ResponseWriter) StatusCode() int {
 func (r *ResponseWriter) WriteHeader(statusCode int) {
 	r.statusCode = statusCode
 	r.ResponseWriter.WriteHeader(statusCode)
+}
+
+// Hijack delegates to the wrapped ResponseWriter, returning an error if the delegate does
+// not implement http.Hijacker.
+func (r *ResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if hijacker, ok := r.ResponseWriter.(http.Hijacker); ok {
+		return hijacker.Hijack()
+	}
+
+	return nil, nil, errors.New("Wrapped response does not implement http.Hijacker")
 }

--- a/health/responseWriter.go
+++ b/health/responseWriter.go
@@ -30,6 +30,18 @@ func (r *ResponseWriter) WriteHeader(statusCode int) {
 	r.ResponseWriter.WriteHeader(statusCode)
 }
 
+// CloseNotify delegates to the wrapped ResponseWriter, panicking if the delegate does
+// not implement http.CloseNotifier.
+func (r *ResponseWriter) CloseNotify() <-chan bool {
+	if closeNotifier, ok := r.ResponseWriter.(http.CloseNotifier); ok {
+		return closeNotifier.CloseNotify()
+	}
+
+	// TODO: Not quite sure what the best thing to do here is.  At least with
+	// a panic, we'll catch it later and can decide what to do.
+	panic(errors.New("Wrapped response does not implement http.CloseNotifier"))
+}
+
 // Hijack delegates to the wrapped ResponseWriter, returning an error if the delegate does
 // not implement http.Hijacker.
 func (r *ResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
@@ -38,4 +50,22 @@ func (r *ResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	}
 
 	return nil, nil, errors.New("Wrapped response does not implement http.Hijacker")
+}
+
+// Flush delegates to the wrapped ResponseWriter.  If the delegate ResponseWriter does not
+// implement http.Flusher, this method does nothing.
+func (r *ResponseWriter) Flush() {
+	if flusher, ok := r.ResponseWriter.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}
+
+// Push delegates to the wrapper ResponseWriter, returning an error if the delegate does
+// not implement http.Pusher.
+func (r *ResponseWriter) Push(target string, opts *http.PushOptions) error {
+	if pusher, ok := r.ResponseWriter.(http.Pusher); ok {
+		return pusher.Push(target, opts)
+	}
+
+	return errors.New("Wrapped response does not implement http.Pusher")
 }

--- a/health/responseWriter_test.go
+++ b/health/responseWriter_test.go
@@ -1,11 +1,16 @@
 package health
 
 import (
-	"github.com/stretchr/testify/assert"
+	"bufio"
+	"bytes"
+	"net"
+	"net/http"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
-func TestResponseWriter(t *testing.T) {
+func testResponseWriterWrapping(t *testing.T) {
 	var (
 		assert    = assert.New(t)
 		delegate  = new(mockResponseWriter)
@@ -19,4 +24,134 @@ func TestResponseWriter(t *testing.T) {
 	assert.Equal(200, composite.StatusCode())
 
 	delegate.AssertExpectations(t)
+}
+
+func testResponseWriterCloseNotifier(t *testing.T) {
+	assert := assert.New(t)
+
+	{
+		var (
+			delegate                     = new(mockResponseWriter)
+			composite http.CloseNotifier = Wrap(delegate)
+		)
+
+		assert.Panics(func() { composite.CloseNotify() })
+		delegate.AssertExpectations(t)
+	}
+
+	{
+		var (
+			delegate                     = new(mockResponseWriterFull)
+			composite http.CloseNotifier = Wrap(delegate)
+
+			closeChannel                = make(chan bool, 1)
+			expectedChannel <-chan bool = closeChannel
+		)
+
+		delegate.On("CloseNotify").Return(expectedChannel).Once()
+		assert.Equal(expectedChannel, composite.CloseNotify())
+		delegate.AssertExpectations(t)
+	}
+}
+
+func testResponseWriterHijacker(t *testing.T) {
+	var (
+		assert                = assert.New(t)
+		expectedConn net.Conn = &net.IPConn{}
+
+		buffer             bytes.Buffer
+		expectedReadWriter = bufio.NewReadWriter(
+			bufio.NewReader(&buffer),
+			bufio.NewWriter(&buffer),
+		)
+	)
+
+	{
+		var (
+			delegate                = new(mockResponseWriter)
+			composite http.Hijacker = Wrap(delegate)
+		)
+
+		conn, rw, err := composite.Hijack()
+		assert.Nil(conn)
+		assert.Nil(rw)
+		assert.Error(err)
+
+		delegate.AssertExpectations(t)
+	}
+
+	{
+		var (
+			delegate                = new(mockResponseWriterFull)
+			composite http.Hijacker = Wrap(delegate)
+		)
+
+		delegate.On("Hijack").Return(expectedConn, expectedReadWriter, error(nil)).Once()
+		conn, rw, err := composite.Hijack()
+		assert.Equal(expectedConn, conn)
+		assert.Equal(expectedReadWriter, rw)
+		assert.NoError(err)
+
+		delegate.AssertExpectations(t)
+	}
+}
+
+func testResponseWriterFlusher(t *testing.T) {
+	{
+		var (
+			delegate               = new(mockResponseWriter)
+			composite http.Flusher = Wrap(delegate)
+		)
+
+		composite.Flush()
+		delegate.AssertExpectations(t)
+	}
+
+	{
+		var (
+			delegate               = new(mockResponseWriterFull)
+			composite http.Flusher = Wrap(delegate)
+		)
+
+		delegate.On("Flush").Once()
+		composite.Flush()
+		delegate.AssertExpectations(t)
+	}
+}
+
+func testResponseWriterPusher(t *testing.T) {
+	var (
+		assert          = assert.New(t)
+		expectedTarget  = "expectedTarget"
+		expectedOptions = &http.PushOptions{Method: "GET"}
+	)
+
+	{
+		var (
+			delegate              = new(mockResponseWriter)
+			composite http.Pusher = Wrap(delegate)
+		)
+
+		assert.Error(composite.Push(expectedTarget, expectedOptions))
+		delegate.AssertExpectations(t)
+	}
+
+	{
+		var (
+			delegate              = new(mockResponseWriterFull)
+			composite http.Pusher = Wrap(delegate)
+		)
+
+		delegate.On("Push", expectedTarget, expectedOptions).Return(error(nil)).Once()
+		assert.NoError(composite.Push(expectedTarget, expectedOptions))
+		delegate.AssertExpectations(t)
+	}
+}
+
+func TestResponseWriter(t *testing.T) {
+	t.Run("Wrapping", testResponseWriterWrapping)
+	t.Run("CloseNotifier", testResponseWriterCloseNotifier)
+	t.Run("Hijacker", testResponseWriterHijacker)
+	t.Run("Flusher", testResponseWriterFlusher)
+	t.Run("Pusher", testResponseWriterPusher)
 }


### PR DESCRIPTION
In addition to http.Hijacker, this PR also adds support for all the net/http optional interfaces.

Gorilla requires http.ResponseWriter to implement http.Hijacker.  However, health.ResponseWriter did not implement it, leading to the current issue with clients being unable to connect.