### PR TITLE
adding "Success" message after registering hooks

### DIFF
--- a/webhook/handler.go
+++ b/webhook/handler.go
@@ -110,4 +110,7 @@ func (r *Registry) UpdateRegistry(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	r.m.Notifier.PublishMessage(string(msg))
+
+	rw.Header().Set("Content-Type", "application/json")
+	rw.Write( []byte(`{"message": "Success"}`) )
 }


### PR DESCRIPTION
Is this how we want a listener registration response message to be?  When registering a hook with this handler, it is sent off to the "publisher" (aws/sns) for registration.  Which fans out to all who are subscribed to that publisher.  In short, is listener registration considered a success if it is sent to the publisher?