### PR TITLE
Allow a *health.Health instance to be passed in.  Allow a nil to take…

### DIFF
--- a/server/webpa_test.go
+++ b/server/webpa_test.go
@@ -2,14 +2,15 @@ package server
 
 import (
 	"errors"
-//	"github.com/Comcast/webpa-common/health"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
+	//	"github.com/Comcast/webpa-common/health"
 	"net/http"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 type mockHandler struct {
@@ -286,7 +287,7 @@ func TestHealthNew(t *testing.T) {
 				Options:            record.options,
 			}
 
-			handler, server = health.New(logger)
+			handler, server = health.New(logger, nil)
 		)
 
 		if len(record.address) > 0 {
@@ -316,7 +317,7 @@ func TestWebPANoPrimaryAddress(t *testing.T) {
 		webPA   = WebPA{}
 
 		_, logger         = newTestLogger()
-		monitor, runnable = webPA.Prepare(logger, handler)
+		monitor, runnable = webPA.Prepare(logger, nil, handler)
 	)
 
 	assert.Nil(monitor)
@@ -363,7 +364,7 @@ func TestWebPA(t *testing.T) {
 		}
 
 		_, logger         = newTestLogger()
-		monitor, runnable = webPA.Prepare(logger, handler)
+		monitor, runnable = webPA.Prepare(logger, nil, handler)
 	)
 
 	assert.NotNil(monitor)


### PR DESCRIPTION
There's a chicken-and-egg problem with the server package:  a lot of code needs the *health.Health instance in order to create the application's http.Handler, but WebPA.Prepare requires an http.Handler and creates the *health.Health instance.

This PR allows the caller the option of passing in a health instance.  For code that doesn't need this complexity, pass nil for *health.Health in WebPA.Prepare and the infrastructure will create the default instance.