### PR TITLE
Feature/better transaction logic

### DIFF
--- a/device/device.go
+++ b/device/device.go
@@ -260,11 +260,11 @@ func (d *device) Send(request *Request) (*Response, error) {
 	}
 
 	var (
-		transactionKey = request.TransactionKey()
-		result         <-chan *Response
+		transactionKey, transactional = request.Transactional()
+		result                        <-chan *Response
 	)
 
-	if len(transactionKey) > 0 {
+	if transactional {
 		var err error
 		if result, err = d.transactions.Register(transactionKey); err != nil {
 			// if a transaction key cannot be registered, we don't want to proceed.

--- a/device/manager.go
+++ b/device/manager.go
@@ -284,9 +284,9 @@ func (m *manager) readPump(d *device, c Connection, closeOnce *sync.Once) {
 		event.SetMessageReceived(d, message, wrp.Msgpack, rawFrame)
 
 		// update any waiting transaction
-		if transactionKey := message.TransactionKey(); len(transactionKey) > 0 {
+		if message.IsTransactionPart() {
 			err := d.transactions.Complete(
-				transactionKey,
+				message.TransactionKey(),
 				&Response{
 					Device:   d,
 					Message:  message,

--- a/device/transactions.go
+++ b/device/transactions.go
@@ -30,14 +30,15 @@ type Request struct {
 	ctx context.Context
 }
 
-// TransactionKey returns the transaction key associated with this request.  If Message is nil
-// or is not an instance of wrp.Routable, this method returns an empty string.
-func (r *Request) TransactionKey() (key string) {
+// Transactional tests if Message is Routable and, if so, returns the transactional information
+// from the request.  This method returns a tuple containing the transaction key (if any) combined with
+// wheither this request represents part of a transaction.
+func (r *Request) Transactional() (string, bool) {
 	if routable, ok := r.Message.(wrp.Routable); ok {
-		key = routable.TransactionKey()
+		return routable.TransactionKey(), routable.IsTransactionPart()
 	}
 
-	return
+	return "", false
 }
 
 // Context returns the context.Context object associated with this Request.


### PR DESCRIPTION
Take into account the msg_type field when determining if a WRP message participates in a transaction.