### PR TITLE
Express metrics configuration externally with a module function for d…

### DIFF
--- a/server/metrics.go
+++ b/server/metrics.go
@@ -1,0 +1,44 @@
+package server
+
+import "github.com/Comcast/webpa-common/xmetrics"
+
+// Metrics is the module function for this package that adds the default request handling metrics.
+func Metrics() []xmetrics.Metric {
+	return []xmetrics.Metric{
+		xmetrics.Metric{
+			Name:       "api_requests_total",
+			Type:       "counter",
+			Help:       "A counter for requests to the handler",
+			LabelNames: []string{"code", "method"},
+		},
+		xmetrics.Metric{
+			Name: "in_flight_requests",
+			Type: "gauge",
+			Help: "A gauge of requests currently being served by the handler.",
+		},
+		xmetrics.Metric{
+			Name:    "request_duration_seconds",
+			Type:    "histogram",
+			Help:    "A histogram of latencies for requests.",
+			Buckets: []float64{.25, .5, 1, 2.5, 5, 10},
+		},
+		xmetrics.Metric{
+			Name:    "request_size_bytes",
+			Type:    "histogram",
+			Help:    "A histogram of request sizes for requests.",
+			Buckets: []float64{200, 500, 900, 1500},
+		},
+		xmetrics.Metric{
+			Name:    "response_size_bytes",
+			Type:    "histogram",
+			Help:    "A histogram of response sizes for requests.",
+			Buckets: []float64{200, 500, 900, 1500},
+		},
+		xmetrics.Metric{
+			Name:    "time_writing_header_seconds",
+			Type:    "histogram",
+			Help:    "A histogram of latencies for writing HTTP headers.",
+			Buckets: []float64{0, 1, 2, 3},
+		},
+	}
+}

--- a/server/webpa_test.go
+++ b/server/webpa_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Comcast/webpa-common/xmetrics"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -314,8 +315,18 @@ func TestWebPANoPrimaryAddress(t *testing.T) {
 	var (
 		assert  = assert.New(t)
 		require = require.New(t)
+	)
+
+	r, err := xmetrics.NewRegistry(nil, Metrics)
+	require.NoError(err)
+	require.NotNil(r)
+
+	var (
 		handler = new(mockHandler)
-		webPA   = WebPA{}
+
+		webPA = WebPA{
+			Provider: r,
+		}
 
 		_, logger         = newTestLogger()
 		monitor, runnable = webPA.Prepare(logger, nil, handler)
@@ -340,7 +351,13 @@ func TestWebPA(t *testing.T) {
 		assert  = assert.New(t)
 		require = require.New(t)
 		handler = new(mockHandler)
+	)
 
+	r, err := xmetrics.NewRegistry(nil, Metrics)
+	require.NoError(err)
+	require.NotNil(r)
+
+	var (
 		// synthesize a WebPA instance that will start everything,
 		// close to how it would be unmarshalled from Viper.
 		webPA = WebPA{
@@ -367,6 +384,8 @@ func TestWebPA(t *testing.T) {
 				Name:    "test.metrics",
 				Address: ":0",
 			},
+
+			Provider: r,
 		}
 
 		_, logger         = newTestLogger()


### PR DESCRIPTION
Here's the integration with the `xmetrics` client package.  When the server is built, a Prometheus-specific factory (a.k.a. provider) is used to create the metrics, which allows us to tweak things in external configuration.  A module-style function is used by applications to establish the default metric configurations.