### PR TITLE
Increase Default ReadTimeout to prevent TLS sycall timeout error

### DIFF
--- a/server/webpa.go
+++ b/server/webpa.go
@@ -32,7 +32,7 @@ const (
 
 	DefaultIdleTimeout       time.Duration = 15 * time.Second
 	DefaultReadHeaderTimeout time.Duration = 0
-	DefaultReadTimeout       time.Duration = 5 * time.Second
+	DefaultReadTimeout       time.Duration = 30 * time.Second
 	DefaultWriteTimeout      time.Duration = 30 * time.Minute
 
 	DefaultMaxHeaderBytes = http.DefaultMaxHeaderBytes


### PR DESCRIPTION
Default ReadTimeout of 5s is not sufficient on clients with high load average. TLS syscall errors are seen for petasos and talaria.