### PR TITLE
Add a new webhook config for basic authentication

### DIFF
--- a/webhook/start.go
+++ b/webhook/start.go
@@ -4,12 +4,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/spf13/viper"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/spf13/viper"
 )
 
 type token string
@@ -20,6 +21,8 @@ type StartConfig struct {
 
 	// path to query for current hooks
 	ApiPath string `json:"apiPath"`
+
+	AuthHeader string `json:"authHeader"`
 
 	// sat configuration data for requesting token
 	Sat struct {
@@ -129,7 +132,12 @@ func (sc *StartConfig) makeRequest() (resp *http.Response, err error) {
 		return
 	}
 	req.Header.Set("content-type", "application/json")
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", sc.Sat.Token))
+
+	if len(sc.Sat.Token) < 1 && len(sc.AuthHeader) > 0 {
+		req.Header.Set("Authorization", fmt.Sprintf("Basic %s", sc.AuthHeader))
+	} else {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", sc.Sat.Token))
+	}
 
 	resp, err = sc.client.Do(req)
 	if err != nil {

--- a/webhook/start_test.go
+++ b/webhook/start_test.go
@@ -168,3 +168,44 @@ func TestGetCurrentSystemsHooks(t *testing.T) {
 		t.Errorf("expected hooks returned to be nil.  got %v", r.Hooks)
 	}
 }
+
+func TestMakeRequestAuthorizationHeader(t *testing.T) {
+	sc := NewStartFactory(nil)
+	sc.client = testClient(t, "Making Requests")
+
+	t.Run("MakeRequestWithoutBearerToken", func(t *testing.T) {
+		sc.Sat.Token = ""
+		sc.AuthHeader = "TheAuthHeader"
+		resp, err := sc.makeRequest()
+
+		if err != nil {
+			t.Errorf("error return while performing request: %v", err)
+		}
+		if resp == nil {
+			t.Error("response returned was nil")
+		}
+
+		var authorizationHeader = resp.Request.Header.Get("Authorization")
+		if authorizationHeader != "Basic TheAuthHeader" {
+			t.Error("authorization header was not \"Basic TheAuthHeader\"")
+		}
+	})
+
+	t.Run("MakeRequestWithBearerToken", func(t *testing.T) {
+		sc.Sat.Token = "TheBearerToken"
+		sc.AuthHeader = "TheAuthHeader"
+		resp, err := sc.makeRequest()
+
+		if err != nil {
+			t.Errorf("error return while performing request: %v", err)
+		}
+		if resp == nil {
+			t.Error("response returned was nil")
+		}
+
+		var authorizationHeader = resp.Request.Header.Get("Authorization")
+		if authorizationHeader != "Bearer TheBearerToken" {
+			t.Error("authorization header was not \"Bearer TheBearerToken\"")
+		}
+	})
+}


### PR DESCRIPTION
This pull request adds and uses a new webhook configuration that allows the servers (i.e. caduceus) to request the webhook listeners from tr1d1um using basic authentication instead of the bearer tokens.

The basic authentication token `authHeader` is only used if a token was not successfully acquired using "Sat".

Since we do not use JWT, this change is vital for our system to work.