### PR TITLE
Update test script to run package tests in parallel

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -7,9 +7,11 @@ coverage_script="$1"
 rm -f *.txt
 
 for package in $(go list ./... | grep -v vendor); do
-	go test -race -coverprofile="coverage-$test_number.txt" $package
+	go test -race -coverprofile="coverage-$test_number.txt" $package &
 	test_number=`expr $test_number + 1`
 done
+
+wait
 
 if [ -n "$coverage_script" ]; then
 	echo "Uploading test coverage results using script: $coverage_script"


### PR DESCRIPTION
From a few runs, running process in parallel speeds up testing time by 46%

Before:
```
ok  	github.com/Comcast/webpa-common/concurrent	2.147s	coverage: 100.0% of statements
ok  	github.com/Comcast/webpa-common/conlimiter	2.984s	coverage: 100.0% of statements
ok  	github.com/Comcast/webpa-common/device	8.739s	coverage: 77.0% of statements
ok  	github.com/Comcast/webpa-common/fact	1.040s	coverage: 100.0% of statements
ok  	github.com/Comcast/webpa-common/garbagetruck	1.021s	coverage: 9.1% of statements
ok  	github.com/Comcast/webpa-common/handler	1.061s	coverage: 92.9% of statements
ok  	github.com/Comcast/webpa-common/hash	1.029s	coverage: 100.0% of statements
ok  	github.com/Comcast/webpa-common/health	1.055s	coverage: 92.0% of statements
ok  	github.com/Comcast/webpa-common/httperror	1.038s	coverage: 100.0% of statements
ok  	github.com/Comcast/webpa-common/httppool	4.192s	coverage: 96.3% of statements
ok  	github.com/Comcast/webpa-common/httppool/health	1.038s	coverage: 100.0% of statements
ok  	github.com/Comcast/webpa-common/logging	1.033s	coverage: 69.4% of statements
ok  	github.com/Comcast/webpa-common/logging/golog	1.703s	coverage: 0.0% of statements
ok  	github.com/Comcast/webpa-common/resource	1.063s	coverage: 100.0% of statements
ok  	github.com/Comcast/webpa-common/secure	1.140s	coverage: 89.0% of statements
ok  	github.com/Comcast/webpa-common/secure/key	1.301s	coverage: 90.5% of statements
?   	github.com/Comcast/webpa-common/secure/tools/cmd/jwt	[no test files]
?   	github.com/Comcast/webpa-common/secure/tools/cmd/keyserver	[no test files]
ok  	github.com/Comcast/webpa-common/server	1.061s	coverage: 100.0% of statements
ok  	github.com/Comcast/webpa-common/service	1.553s	coverage: 94.6% of statements
?   	github.com/Comcast/webpa-common/service/cmd/endpoint	[no test files]
ok  	github.com/Comcast/webpa-common/store	2.138s	coverage: 97.9% of statements
ok  	github.com/Comcast/webpa-common/types	1.022s	coverage: 83.3% of statements
?   	github.com/Comcast/webpa-common/webhook	[no test files]
ok  	github.com/Comcast/webpa-common/webhook/aws	1.036s	coverage: 90.0% of statements
ok  	github.com/Comcast/webpa-common/wrp	1.104s	coverage: 100.0% of statements
It took 298 seconds to finish running tests
```

After:

```
?   	github.com/Comcast/webpa-common/secure/tools/cmd/jwt	[no test files]
ok  	github.com/Comcast/webpa-common/types	1.030s	coverage: 83.3% of statements
ok  	github.com/Comcast/webpa-common/garbagetruck	4.033s	coverage: 9.1% of statements
ok  	github.com/Comcast/webpa-common/logging/golog	1.034s	coverage: 0.0% of statements
ok  	github.com/Comcast/webpa-common/concurrent	2.173s	coverage: 100.0% of statements
?   	github.com/Comcast/webpa-common/webhook	[no test files]
ok  	github.com/Comcast/webpa-common/logging	1.049s	coverage: 69.4% of statements
ok  	github.com/Comcast/webpa-common/hash	1.089s	coverage: 100.0% of statements
ok  	github.com/Comcast/webpa-common/httperror	1.049s	coverage: 100.0% of statements
ok  	github.com/Comcast/webpa-common/resource	1.098s	coverage: 100.0% of statements
?   	github.com/Comcast/webpa-common/secure/tools/cmd/keyserver	[no test files]
ok  	github.com/Comcast/webpa-common/conlimiter	1.837s	coverage: 100.0% of statements
?   	github.com/Comcast/webpa-common/service/cmd/endpoint	[no test files]
ok  	github.com/Comcast/webpa-common/secure/key	1.354s	coverage: 90.5% of statements
ok  	github.com/Comcast/webpa-common/health	1.084s	coverage: 92.0% of statements
ok  	github.com/Comcast/webpa-common/httppool/health	1.053s	coverage: 100.0% of statements
ok  	github.com/Comcast/webpa-common/webhook/aws	1.058s	coverage: 90.0% of statements
ok  	github.com/Comcast/webpa-common/store	2.151s	coverage: 97.9% of statements
ok  	github.com/Comcast/webpa-common/secure	1.289s	coverage: 89.0% of statements
ok  	github.com/Comcast/webpa-common/server	1.086s	coverage: 100.0% of statements
ok  	github.com/Comcast/webpa-common/service	2.054s	coverage: 94.6% of statements
ok  	github.com/Comcast/webpa-common/httppool	5.870s	coverage: 96.3% of statements
ok  	github.com/Comcast/webpa-common/wrp	1.118s	coverage: 100.0% of statements
ok  	github.com/Comcast/webpa-common/fact	1.040s	coverage: 100.0% of statements
ok  	github.com/Comcast/webpa-common/handler	1.057s	coverage: 92.9% of statements
ok  	github.com/Comcast/webpa-common/device	7.925s	coverage: 77.0% of statements
It took 136 seconds to finish running tests
```