### PR TITLE
simplify test script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go: 
-    - 1.9.2
+    - "1.10"
 
 before_install:
     - sudo pip install --user codecov

--- a/service/instance.go
+++ b/service/instance.go
@@ -58,7 +58,7 @@ func NormalizeInstance(defaultScheme, instance string) (string, error) {
 
 	submatches := instancePattern.FindStringSubmatch(instance)
 	if len(submatches) == 0 {
-		return instance, fmt.Errorf("Invalid instance: %s")
+		return instance, fmt.Errorf("Invalid instance: %s", instance)
 	}
 
 	var (

--- a/test.sh
+++ b/test.sh
@@ -3,6 +3,8 @@
 set -e
 coverage_script="$1"
 
+-rm -f *.txt
+
 # ./... ignores vendor: https://golang.org/doc/go1.9#vendor-dotdotdot
 go test -race -coverprofile="coverage.txt" ./...
 

--- a/test.sh
+++ b/test.sh
@@ -3,7 +3,7 @@
 set -e
 coverage_script="$1"
 
--rm -f *.txt
+rm -f *.txt
 
 # ./... ignores vendor: https://golang.org/doc/go1.9#vendor-dotdotdot
 go test -race -coverprofile="coverage.txt" ./...

--- a/test.sh
+++ b/test.sh
@@ -1,22 +1,10 @@
 #/bin/sh
 
 set -e
-test_number=1
 coverage_script="$1"
 
-rm -f *.txt
-pids=()
-
-for package in $(go list ./... | grep -v vendor); do
-	go test -race -coverprofile="coverage-$test_number.txt" $package &
-	pids=(${pids[@]} $!)
-	test_number=`expr $test_number + 1`
-done
-
-for pid in ${pids[@]}
-do
-	wait $pid
-done
+# ./... ignores vendor: https://golang.org/doc/go1.9#vendor-dotdotdot
+go test -race -coverprofile="coverage.txt" ./...
 
 if [ -n "$coverage_script" ]; then
 	echo "Uploading test coverage results using script: $coverage_script"


### PR DESCRIPTION
This simplifies the test script by using the existing go tool capabilities to run all package tests in parallel:

According to the docs (https://golang.org/cmd/go/#hdr-Compile_packages_and_dependencies), we can configure the number of tests that can run in parallel with the `-p` flag. I left it out as the default is the available number of CPUs which seems like a good starting point. 

*Note:* "all packages" above refers to packages in `webpa-common` except those under vendor\ (https://tip.golang.org/doc/go1.9#vendor-dotdotdot)

**Dependency:** needs go version >= `1.10`. Specifically, the docs( https://golang.org/doc/go1.10#test) describe that the "`go test -coverprofile` option is now supported when running multiple tests"

