### PR TITLE
Add convey payload to connect event

### DIFF
--- a/device/manager.go
+++ b/device/manager.go
@@ -1,6 +1,7 @@
 package device
 
 import (
+	"encoding/json"
 	"io"
 	"net/http"
 	"sync"
@@ -154,10 +155,11 @@ func (m *manager) Connect(response http.ResponseWriter, request *http.Request, r
 	}
 
 	d := newDevice(deviceOptions{ID: id, QueueSize: m.deviceMessageQueueSize, Logger: m.logger})
-	if convey, err := m.conveyTranslator.FromHeader(request.Header); err == nil {
+	convey, conveyErr := m.conveyTranslator.FromHeader(request.Header)
+	if conveyErr == nil {
 		d.infoLog.Log("convey", convey)
-	} else if err != conveyhttp.ErrMissingHeader {
-		d.errorLog.Log(logging.MessageKey(), "badly formatted convey data", logging.ErrorKey(), err)
+	} else if conveyErr != conveyhttp.ErrMissingHeader {
+		d.errorLog.Log(logging.MessageKey(), "badly formatted convey data", logging.ErrorKey(), conveyErr)
 	}
 
 	c, err := m.upgrader.Upgrade(response, request, responseHeader)
@@ -181,12 +183,20 @@ func (m *manager) Connect(response http.ResponseWriter, request *http.Request, r
 		return nil, err
 	}
 
-	m.dispatch(
-		&Event{
-			Type:   Connect,
-			Device: d,
-		},
-	)
+	event := &Event{
+		Type:   Connect,
+		Device: d,
+	}
+
+	if conveyErr == nil {
+		bytes, err := json.Marshal(convey)
+		if err != nil {
+			event.Format = wrp.JSON
+			event.Contents = bytes
+		}
+	}
+
+	m.dispatch(event)
 
 	SetPongHandler(c, m.measures.Pong, m.readDeadline)
 	closeOnce := new(sync.Once)

--- a/device/manager.go
+++ b/device/manager.go
@@ -190,9 +190,11 @@ func (m *manager) Connect(response http.ResponseWriter, request *http.Request, r
 
 	if conveyErr == nil {
 		bytes, err := json.Marshal(convey)
-		if err != nil {
+		if err == nil {
 			event.Format = wrp.JSON
 			event.Contents = bytes
+		} else {
+			d.errorLog.Log(logging.MessageKey(), "unable to marshal the convey header", logging.ErrorKey(), err)
 		}
 	}
 

--- a/device/manager_test.go
+++ b/device/manager_test.go
@@ -325,6 +325,7 @@ func testManagerConnectIncludesConvey(t *testing.T) {
 				"hw-serial-number":123456789,
 				"webpa-protocol":"WebPA-1.6"
 			}
+
 	*/
 	header := &http.Header{
 		"X-Webpa-Convey": {"eyAgDQogICAiaHctc2VyaWFsLW51bWJlciI6MTIzNDU2Nzg5LA0KICAgIndlYnBhLXByb3RvY29sIjoiV2ViUEEtMS42Ig0KfQ=="},
@@ -343,11 +344,11 @@ func testManagerConnectIncludesConvey(t *testing.T) {
 
 	content := <-contents
 	convey := make(map[string]interface{})
-	err = json.Unmarshal(content, convey)
+	err = json.Unmarshal(content, &convey)
 
 	assert.Nil(err)
 	assert.Equal(2, len(convey))
-	assert.Equal(123456789, convey["hw-serial-number"])
+	assert.Equal(float64(123456789), convey["hw-serial-number"])
 	assert.Equal("WebPA-1.6", convey["webpa-protocol"])
 }
 
@@ -356,6 +357,7 @@ func TestManager(t *testing.T) {
 		t.Run("MissingDeviceContext", testManagerConnectMissingDeviceContext)
 		t.Run("UpgradeError", testManagerConnectUpgradeError)
 		t.Run("Visit", testManagerConnectVisit)
+		t.Run("IncludesConvey", testManagerConnectIncludesConvey)
 	})
 
 	t.Run("Route", func(t *testing.T) {


### PR DESCRIPTION
This change adds the convey payload to the Connect event as discussed in #271. 
When used together with Comcast/talaria#43 will allow us to take more informed actions based on the device state.