### PR TITLE
Add support for overriding the AWS endpoint

### DIFF
--- a/webhook/aws/sns.go
+++ b/webhook/aws/sns.go
@@ -34,6 +34,7 @@ type SNSConfig struct {
 	Region   string `json:"region"`
 	TopicArn string `json:"topicArn"`
 	UrlPath  string `json:"urlPath"` //uri path to register mux
+	AwsEndpoint string `json:"awsEndpoint"`
 }
 
 type SNSServer struct {
@@ -75,6 +76,7 @@ func NewSNSServer(v *viper.Viper) (ss *SNSServer, err error) {
 
 	sess, aws_err := session.NewSession(&aws.Config{
 		Region:      aws.String(cfg.Sns.Region),
+		Endpoint:    aws.String(cfg.Sns.AwsEndpoint),
 		Credentials: cred,
 	})
 	if aws_err != nil {

--- a/webhook/aws/sns_test.go
+++ b/webhook/aws/sns_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Comcast/webpa-common/xmetrics"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/sns"
-	"github.com/Comcast/webpa-common/xmetrics"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -53,6 +53,7 @@ func TestNewSNSServerSuccess(t *testing.T) {
 	assert.NotNil(ss.SNSValidator)
 	assert.Equal("test", ss.Config.Env)
 	assert.Equal("us-east-1", ss.Config.Sns.Region)
+	assert.Equal("http://example.com", ss.Config.Sns.AwsEndpoint)
 }
 
 func TestNewSNSServerAWSConfigError(t *testing.T) {
@@ -77,6 +78,7 @@ func TestNewSNSServerViperNil(t *testing.T) {
 	assert.NotNil(ss.Config)
 	assert.Equal(ss.Config.AccessKey, "test-accessKey")
 	assert.Equal(ss.Config.Sns.TopicArn, "arn:aws:sns:us-east-1:1234:test-topic")
+	assert.Equal("", ss.Config.Sns.AwsEndpoint)
 	assert.NotNil(ss.SNSValidator)
 }
 

--- a/webhook/aws/sns_test_support.go
+++ b/webhook/aws/sns_test_support.go
@@ -19,7 +19,8 @@ const (
 	        "region" : "us-east-1",
             "protocol" : "http",
 			"topicArn" : "arn:aws:sns:us-east-1:1234:test-topic", 
-			"urlPath" : "/api/v2/aws/sns"
+			"urlPath" : "/api/v2/aws/sns",
+			"awsEndpoint" : "http://example.com"
     } } }`
 	TEST_SUB_MSG = `{
 	"Type" : "SubscriptionConfirmation",


### PR DESCRIPTION
This PR adds a configuration for the AWS endpoint, allowing us to use a SNS emulator.