### PR TITLE
adding wait logic for webhook/aws.  when used, this allows a service …

### DIFF
--- a/webhook/aws/metrics.go
+++ b/webhook/aws/metrics.go
@@ -6,6 +6,8 @@ import (
 )
 
 const (
+	DnsReadyQueryCount      = "dns_ready_query_count"
+	DnsReady                = "dns_ready"
 	SNSNotificationReceived = "webhook_sns_notification_received_count"
 	SNSNotificationSent     = "webhook_sns_notification_sent_count"
 	SNSSubscribeAttempt     = "webhook_sns_subscribe_attempt_count"
@@ -13,6 +15,8 @@ const (
 )
 
 type AWSMetrics struct {
+	DnsReadyQueryCount      metrics.Counter
+	DnsReady                metrics.Gauge
 	SNSNotificationReceived metrics.Counter
 	SNSNotificationSent     metrics.Counter
 	SNSSubscribeAttempt     metrics.Counter
@@ -22,6 +26,16 @@ type AWSMetrics struct {
 // Metrics returns the defined metrics as a list
 func Metrics() []xmetrics.Metric {
 	return []xmetrics.Metric{
+		xmetrics.Metric{
+			Name: DnsReadyQueryCount,
+			Help: "Count of the number of queries made checking if DNS is ready",
+			Type: "counter",
+		},
+		xmetrics.Metric{
+			Name: DnsReady,
+			Help: "Is the DNS ready",
+			Type: "gauge",
+		},
 		xmetrics.Metric{
 			Name:       SNSNotificationReceived,
 			Help:       "Count of the number SNS notifications received",
@@ -52,6 +66,12 @@ func Metrics() []xmetrics.Metric {
 func ApplyMetricsData(registry xmetrics.Registry) (m AWSMetrics) {
 	for _, metric := range Metrics() {
 		switch metric.Name {
+		case DnsReadyQueryCount:
+			m.DnsReadyQueryCount = registry.NewCounter(metric.Name)
+			m.DnsReadyQueryCount.Add(0.0)
+		case DnsReady:
+			m.DnsReady = registry.NewGauge(metric.Name)
+			m.DnsReady.Add(0.0)
 		case SNSNotificationReceived:
 			m.SNSNotificationReceived = registry.NewCounter(metric.Name)
 		case SNSNotificationSent:

--- a/webhook/aws/sns_test.go
+++ b/webhook/aws/sns_test.go
@@ -27,6 +27,7 @@ const (
 		                }
 		          }`
 	TEST_AWS_CFG = `{
+	"waitForDns": "2000000000",
 	"aws": {
         "accessKey": "accessKey",
         "secretKey": "secretKey",
@@ -158,4 +159,25 @@ func TestInitialize_SNSUrlPathWithSlash(t *testing.T) {
 	require.NotNil(ss.debugLog)
 	assert.Equal(fmt.Sprint(ss.Config.Sns.UrlPath, TEST_UNIX_TIME), selfUrl.Path)
 	assert.Equal("http://host-test:port/sns/1503357402", ss.SelfUrl.String())
+}
+
+func TestDnsReady(t *testing.T) {
+	assert := assert.New(t)
+
+	v := SetUpTestViperInstance(TEST_AWS_CFG)
+	ss, err := NewNotifier(v)
+
+	assert.Nil(err)
+	assert.NotNil(ss)
+
+	selfUrl := &url.URL{
+		Scheme: "http",
+		Host:   "host:port",
+	}
+	registry, _ := xmetrics.NewRegistry(&xmetrics.Options{}, Metrics)
+	ss.Initialize(nil, selfUrl, nil, nil, registry, func() time.Time { return time.Unix(TEST_UNIX_TIME, 0) })
+
+	err = ss.DnsReady()
+
+	assert.NotNil(err)
 }


### PR DESCRIPTION
…to wait for its DNS to propagate before attempting to subscribe to AWS SNS.