### PR TITLE
fixing the possibility of `PublishMessage` hanging

### DIFF
--- a/webhook/aws/sns_example_test.go
+++ b/webhook/aws/sns_example_test.go
@@ -96,7 +96,10 @@ func testPublish(t *testing.T, m *MockSVC, ss *SNSServer) {
 	// mocking SNS Publish response
 	m.On("Publish", mock.AnythingOfType("*sns.PublishInput")).Return(&sns.PublishOutput{}, nil)
 
-	ss.PublishMessage(TEST_HOOK)
+	err := ss.PublishMessage(TEST_HOOK)
+	if nil != err {
+		panic(err)
+	}
 
 	// wait such that listenAndPublishMessage go routine will publish message
 	time.Sleep(1 * time.Second)

--- a/webhook/aws/sns_test_support.go
+++ b/webhook/aws/sns_test_support.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"github.com/gorilla/mux"
+	"time"
 )
 
 type ErrResp struct {
@@ -90,6 +91,8 @@ func SetUpTestNotifier() (Notifier, *MockSVC, *MockValidator, *mux.Router) {
 		Config:       *awsCfg,
 		SVC:          m,
 		SNSValidator: mv,
+		channelSize: 50,
+		channelClientTimeout: 30 * time.Second,
 	}
 
 	r := mux.NewRouter()


### PR DESCRIPTION
- the hanging could happen by the channel not being emptied from the
  inability to talk to SNS
- two new configurations were added to viper
  - sns.channelSize the size of the channel to buffer the messages
  - sns.channelClientTimeout the timeout for adding messages to buffer