### PR TITLE
 added ability to add error handler

### DIFF
--- a/xhttp/fanout/handler.go
+++ b/xhttp/fanout/handler.go
@@ -290,8 +290,7 @@ func (h *Handler) finish(logger log.Logger, response http.ResponseWriter, result
 		count, err := response.Write(result.Body)
 		logLevel := level.DebugValue()
 		if err != nil {
-			logLevel = level.ErrorValue()
-			logger.Log(level.Key(), logLevel, logging.MessageKey(), "wrote fanout response", "bytes", count, logging.ErrorKey(), err)
+			logger.Log(level.Key(), level.ErrorValue(), logging.MessageKey(), "wrote fanout response", "bytes", count, logging.ErrorKey(), err)
 		} else {
 			logger.Log(level.Key(), logLevel, logging.MessageKey(), "wrote fanout response", "bytes", count)
 		}
@@ -322,16 +321,13 @@ func (h *Handler) handleErrorFinish(logger log.Logger, response http.ResponseWri
 		count, err := response.Write(result.Body)
 		logLevel := level.DebugValue()
 		if err != nil {
-			logLevel = level.ErrorValue()
-			logger.Log(level.Key(), logLevel, logging.MessageKey(), "wrote fanout response", "bytes", count, logging.ErrorKey(), err)
-			return
+			logger.Log(level.Key(), level.ErrorValue(), logging.MessageKey(), "wrote fanout response", "bytes", count, logging.ErrorKey(), err)
+		} else {
+			logger.Log(level.Key(), logLevel, logging.MessageKey(), "wrote fanout response", "bytes", count)
 		}
-
-		logger.Log(level.Key(), logLevel, logging.MessageKey(), "wrote fanout response", "bytes", count)
 	} else {
 		response.WriteHeader(result.StatusCode)
 	}
-
 }
 
 func (h *Handler) ServeHTTP(response http.ResponseWriter, original *http.Request) {
@@ -369,8 +365,7 @@ func (h *Handler) ServeHTTP(response http.ResponseWriter, original *http.Request
 			tracinghttp.HeadersForSpans("", response.Header(), r.Span)
 			logLevel := level.DebugValue()
 			if r.Err != nil {
-				logLevel = level.ErrorValue()
-				logger.Log(level.Key(), logLevel, logging.MessageKey(), "fanout request complete", "statusCode", r.StatusCode, "url", r.Request.URL, logging.ErrorKey(), r.Err)
+				logger.Log(level.Key(), level.ErrorValue(), logging.MessageKey(), "fanout request complete", "statusCode", r.StatusCode, "url", r.Request.URL, logging.ErrorKey(), r.Err)
 			} else {
 				logger.Log(level.Key(), logLevel, logging.MessageKey(), "fanout request complete", "statusCode", r.StatusCode, "url", r.Request.URL)
 			}

--- a/xhttp/fanout/handler.go
+++ b/xhttp/fanout/handler.go
@@ -104,9 +104,9 @@ func WithClientAfter(after ...gokithttp.ClientResponseFunc) Option {
 	}
 }
 
-// WithFadeoutFailure adds zero or more response functions that are invoked to tailor the response
+// WithFanoutFailure adds zero or more response functions that are invoked to tailor the response
 // when a failed fanout responses have been received.
-func WithFadeoutFailure(failure ...FanoutResponseFunc) Option {
+func WithFanoutFailure(failure ...FanoutResponseFunc) Option {
 	return func(h *Handler) {
 		h.failure = append(h.failure, failure...)
 	}

--- a/xhttp/fanout/handler.go
+++ b/xhttp/fanout/handler.go
@@ -288,11 +288,10 @@ func (h *Handler) finish(logger log.Logger, response http.ResponseWriter, result
 
 		response.WriteHeader(result.StatusCode)
 		count, err := response.Write(result.Body)
-		logLevel := level.DebugValue()
 		if err != nil {
 			logger.Log(level.Key(), level.ErrorValue(), logging.MessageKey(), "wrote fanout response", "bytes", count, logging.ErrorKey(), err)
 		} else {
-			logger.Log(level.Key(), logLevel, logging.MessageKey(), "wrote fanout response", "bytes", count)
+			logger.Log(level.Key(), level.DebugValue(), logging.MessageKey(), "wrote fanout response", "bytes", count)
 		}
 
 	} else {
@@ -319,13 +318,13 @@ func (h *Handler) handleErrorFinish(logger log.Logger, response http.ResponseWri
 
 		response.WriteHeader(result.StatusCode)
 		count, err := response.Write(result.Body)
-		logLevel := level.DebugValue()
 		if err != nil {
-			logger.Log(level.Key(), level.ErrorValue(), logging.MessageKey(), "wrote fanout response", "bytes", count, logging.ErrorKey(), err)
+			logger.Log(level.Key(), level.ErrorValue(), logging.MessageKey(), "wrote fanout error response", "bytes", count, logging.ErrorKey(), err)
 		} else {
-			logger.Log(level.Key(), logLevel, logging.MessageKey(), "wrote fanout response", "bytes", count)
+			logger.Log(level.Key(), level.DebugValue(), logging.MessageKey(), "wrote fanout error response", "bytes", count)
 		}
 	} else {
+		logger.Log(level.Key(), level.DebugValue(), logging.MessageKey(), "wrote fanout error response", "statusCode", result.StatusCode)
 		response.WriteHeader(result.StatusCode)
 	}
 }
@@ -363,11 +362,10 @@ func (h *Handler) ServeHTTP(response http.ResponseWriter, original *http.Request
 
 		case r := <-results:
 			tracinghttp.HeadersForSpans("", response.Header(), r.Span)
-			logLevel := level.DebugValue()
 			if r.Err != nil {
 				logger.Log(level.Key(), level.ErrorValue(), logging.MessageKey(), "fanout request complete", "statusCode", r.StatusCode, "url", r.Request.URL, logging.ErrorKey(), r.Err)
 			} else {
-				logger.Log(level.Key(), logLevel, logging.MessageKey(), "fanout request complete", "statusCode", r.StatusCode, "url", r.Request.URL)
+				logger.Log(level.Key(), level.DebugValue(), logging.MessageKey(), "fanout request complete", "statusCode", r.StatusCode, "url", r.Request.URL)
 			}
 
 			if h.shouldTerminate(r) {
@@ -384,6 +382,5 @@ func (h *Handler) ServeHTTP(response http.ResponseWriter, original *http.Request
 	}
 
 	logger.Log(level.Key(), level.ErrorValue(), logging.MessageKey(), "all fanout requests failed", "statusCode", statusCode, "url", original.URL)
-	//response.WriteHeader(statusCode)
 	h.handleErrorFinish(logger, response, latestResponse)
 }

--- a/xhttp/fanout/handler.go
+++ b/xhttp/fanout/handler.go
@@ -104,16 +104,16 @@ func WithClientAfter(after ...gokithttp.ClientResponseFunc) Option {
 	}
 }
 
-// WithFanoutAfter adds zero or more response functions that are invoked to tailor the response
-// when a successful (i.e. terminating) fanout response is received.
-func WithFanoutFaliure(failure ...FanoutResponseFunc) Option {
+// WithFadeoutFailure adds zero or more response functions that are invoked to tailor the response
+// when a failed fanout responses have been received.
+func WithFadeoutFailure(failure ...FanoutResponseFunc) Option {
 	return func(h *Handler) {
 		h.failure = append(h.failure, failure...)
 	}
 }
 
-// WithClientAfter allows zero or more go-kit ClientResponseFuncs to be used as fanout after functions.
-func WithClientFaliure(failure ...gokithttp.ClientResponseFunc) Option {
+// WithClientFailure allows zero or more go-kit ClientResponseFuncs to be used as fanout failure functions.
+func WithClientFailure(failure ...gokithttp.ClientResponseFunc) Option {
 	return func(h *Handler) {
 		for _, rf := range failure {
 			h.failure = append(

--- a/xhttp/fanout/handler_test.go
+++ b/xhttp/fanout/handler_test.go
@@ -182,7 +182,7 @@ func testHandlerGet(t *testing.T, expectedResponses []xhttptest.ExpectedResponse
 			WithClientBefore(gokithttp.SetRequestHeader("X-Test", "foobar")),
 			WithFanoutAfter(fanoutAfter),
 			WithClientAfter(clientAfter),
-			WithFadeoutFailure(fanoutFail),
+			WithFanoutFailure(fanoutFail),
 		)
 	)
 
@@ -263,7 +263,7 @@ func testHandlerPost(t *testing.T, expectedResponses []xhttptest.ExpectedRespons
 			WithClientBefore(gokithttp.SetRequestHeader("X-Test", "foobar")),
 			WithFanoutAfter(fanoutAfter),
 			WithClientAfter(clientAfter),
-			WithFadeoutFailure(fanoutFail),
+			WithFanoutFailure(fanoutFail),
 		)
 	)
 
@@ -483,7 +483,7 @@ func testNewNilConfiguration(t *testing.T) {
 			WithFanoutBefore(),
 			WithClientBefore(),
 			WithFanoutAfter(),
-			WithFadeoutFailure(),
+			WithFanoutFailure(),
 			WithClientFailure(),
 		)
 	)

--- a/xhttp/fanout/handler_test.go
+++ b/xhttp/fanout/handler_test.go
@@ -182,7 +182,7 @@ func testHandlerGet(t *testing.T, expectedResponses []xhttptest.ExpectedResponse
 			WithClientBefore(gokithttp.SetRequestHeader("X-Test", "foobar")),
 			WithFanoutAfter(fanoutAfter),
 			WithClientAfter(clientAfter),
-			WithFanoutFaliure(fanoutFail),
+			WithFadeoutFailure(fanoutFail),
 		)
 	)
 
@@ -263,7 +263,7 @@ func testHandlerPost(t *testing.T, expectedResponses []xhttptest.ExpectedRespons
 			WithClientBefore(gokithttp.SetRequestHeader("X-Test", "foobar")),
 			WithFanoutAfter(fanoutAfter),
 			WithClientAfter(clientAfter),
-			WithFanoutFaliure(fanoutFail),
+			WithFadeoutFailure(fanoutFail),
 		)
 	)
 
@@ -483,8 +483,8 @@ func testNewNilConfiguration(t *testing.T) {
 			WithFanoutBefore(),
 			WithClientBefore(),
 			WithFanoutAfter(),
-			WithFanoutFaliure(),
-			WithClientFaliure(),
+			WithFadeoutFailure(),
+			WithClientFailure(),
 		)
 	)
 


### PR DESCRIPTION
If a fanout fails you can provide custom logic.

aka with `scytale` receiving 404s and forwarding headers.