### PR TITLE
removed creation of 150byte Buffer

### DIFF
--- a/device/statistics.go
+++ b/device/statistics.go
@@ -1,7 +1,6 @@
 package device
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"sync"
@@ -168,10 +167,8 @@ func (s *statistics) String() string {
 }
 
 func (s *statistics) MarshalJSON() ([]byte, error) {
-	output := bytes.NewBuffer(make([]byte, 0, 150))
 	s.lock.RLock()
-	_, err := fmt.Fprintf(
-		output,
+	output := []byte(fmt.Sprintf(
 		`{"bytesSent": %d, "messagesSent": %d, "bytesReceived": %d, "messagesReceived": %d, "duplications": %d, "connectedAt": "%s", "upTime": "%s"}`,
 		s.bytesSent,
 		s.messagesSent,
@@ -180,8 +177,7 @@ func (s *statistics) MarshalJSON() ([]byte, error) {
 		s.duplications,
 		s.formattedConnectedAt,
 		s.UpTime(),
-	)
-
+	))
 	s.lock.RUnlock()
-	return output.Bytes(), err
+	return output, nil
 }

--- a/device/statistics_test.go
+++ b/device/statistics_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const EqualityThreshold = 1000
+const EqualityThreshold = 4000
 
 func Abs(n int64) int64 {
 	if n < 0 {

--- a/device/statistics_test.go
+++ b/device/statistics_test.go
@@ -3,6 +3,7 @@ package device
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"sync"
 	"testing"
 	"time"
@@ -10,6 +11,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+const EqualityThreshold = 1000
+
+func almostEqual(a, b time.Duration) bool {
+	return math.Abs(float64(a-b)) <= EqualityThreshold
+}
 
 func testStatisticsInitialStateDefaultNow(t *testing.T) {
 	var (
@@ -29,7 +36,7 @@ func testStatisticsInitialStateDefaultNow(t *testing.T) {
 	assert.Zero(statistics.MessagesReceived())
 	assert.Zero(statistics.Duplications())
 	assert.Equal(expectedConnectedAt.UTC(), statistics.ConnectedAt())
-	assert.True(time.Now().Sub(expectedConnectedAt) <= statistics.UpTime())
+	assert.True(almostEqual(time.Now().Sub(expectedConnectedAt), statistics.UpTime()))
 
 	data, err := statistics.MarshalJSON()
 	require.NotEmpty(data)

--- a/device/statistics_test.go
+++ b/device/statistics_test.go
@@ -41,9 +41,11 @@ func testStatisticsInitialStateDefaultNow(t *testing.T) {
 	assert.Zero(statistics.MessagesReceived())
 	assert.Zero(statistics.Duplications())
 	assert.Equal(expectedConnectedAt.UTC(), statistics.ConnectedAt())
-	assert.True(almostEqual(time.Now().Sub(expectedConnectedAt), statistics.UpTime()),
+	expectedUpTime := time.Now().Sub(expectedConnectedAt)
+	uptime := statistics.UpTime()
+	assert.True(almostEqual(expectedUpTime, uptime),
 		"TimeSince Connected %dns,  UpTime %dns with a margin of %d, actual %d",
-		time.Now().Sub(expectedConnectedAt).Nanoseconds(), statistics.UpTime().Nanoseconds(), EqualityThreshold, Abs(time.Now().Sub(expectedConnectedAt).Nanoseconds()-statistics.UpTime().Nanoseconds()))
+		expectedUpTime.Nanoseconds(), uptime.Nanoseconds(), EqualityThreshold, Abs(expectedUpTime.Nanoseconds()-uptime.Nanoseconds()))
 
 	data, err := statistics.MarshalJSON()
 	require.NotEmpty(data)

--- a/device/statistics_test.go
+++ b/device/statistics_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const EqualityThreshold = 4000
+const EqualityThreshold = 5000
 
 func Abs(n int64) int64 {
 	if n < 0 {


### PR DESCRIPTION
Under a large amount of connections and then all of them dropping, these 150bytes add up.

Also updated a test as `time.Now().Sub(expectedConnectedAt)` wasn't consistently less than `statistics.UpTime()`

