### PR TITLE
adding WaitGroup to prevent concurrent writes

### DIFF
--- a/device/manager.go
+++ b/device/manager.go
@@ -324,6 +324,9 @@ func (m *manager) writePump(d *device, w WriteCloser, pinger func() error, close
 	defer d.debugLog.Log(logging.MessageKey(), "writePump exiting")
 	d.debugLog.Log(logging.MessageKey(), "writePump starting")
 
+	wg := new(sync.WaitGroup)
+	wg.Add(1)
+
 	var (
 		envelope   *envelope
 		encoder    = wrp.NewEncoder(nil, wrp.Msgpack)
@@ -337,6 +340,7 @@ func (m *manager) writePump(d *device, w WriteCloser, pinger func() error, close
 			// triggers.  This is only a problem if a device connects then disconnects faster
 			// than the authDelay setting.
 			w.WritePreparedMessage(authStatus)
+			wg.Done()
 		})
 	)
 
@@ -406,6 +410,7 @@ func (m *manager) writePump(d *device, w WriteCloser, pinger func() error, close
 			}
 
 			if writeError == nil {
+				wg.Wait()
 				writeError = w.WriteMessage(websocket.BinaryMessage, frameContents)
 			}
 


### PR DESCRIPTION
A weird timing issue can cause talaria to panic and fall over.

In its current state it is possible to send an authStatus and an envelope message from device messages at the same time. causing  `panic: concurrent write to websocket connection`

This fix prevents the crash by forcing all envelope messages to wait until the authStatus message completes.