### PR TITLE
Adding custom resolver package

### DIFF
--- a/xresolver/consul/consullistener.go
+++ b/xresolver/consul/consullistener.go
@@ -1,0 +1,74 @@
+package consul
+
+import (
+	"context"
+	"errors"
+	"github.com/Comcast/webpa-common/logging"
+	"github.com/Comcast/webpa-common/service/monitor"
+	"github.com/Comcast/webpa-common/xresolver"
+	"github.com/go-kit/kit/log"
+
+	"regexp"
+)
+
+var find = regexp.MustCompile("(.*)" + regexp.QuoteMeta("[") + "(.*)" + regexp.QuoteMeta("]") + regexp.QuoteMeta("{") + "(.*)" + regexp.QuoteMeta("}"))
+
+type Options struct {
+	// Watch is what to url to match with the consul service
+	// exp. { "beta.google.com" : "caduceus" }
+	Watch map[string]string `json:"watch"`
+
+	logger log.Logger `json:"-"`
+}
+
+type ConsulWatcher struct {
+	balancers map[string]*xresolver.RoundRobin
+	config    *Options
+}
+
+func NewConsulWatcher(o *Options) *ConsulWatcher {
+	if o.logger == nil {
+		o.logger = logging.DefaultLogger()
+	}
+
+	balancers := make(map[string]*xresolver.RoundRobin)
+	for _, service := range o.Watch {
+		if _, found := balancers[service]; !found {
+			balancers[service] = xresolver.NewRoundRobinBalancer()
+		}
+	}
+	watcher := &ConsulWatcher{
+		balancers: balancers,
+		config:    o,
+	}
+
+	return watcher
+}
+
+func (watcher *ConsulWatcher) MonitorEvent(e monitor.Event) {
+	// update balancers
+	str := find.FindStringSubmatch(e.Key)
+	if len(str) < 3 {
+		return
+	}
+	if rr, found := watcher.balancers[str[1]]; found {
+		routes := make([]xresolver.Route, len(e.Instances))
+		for index, instance := range e.Instances {
+			// find records
+			route, err := xresolver.CreateRoute(instance)
+			if err != nil {
+				logging.Warn(watcher.config.logger).Log(logging.MessageKey(), "failed to create route", logging.MessageKey(), err, "instance", instance)
+				continue
+			}
+			routes[index] = *route
+		}
+		rr.Update(routes)
+	}
+}
+
+func (watcher *ConsulWatcher) LookupRoutes(ctx context.Context, host string) ([]xresolver.Route, error) {
+	if _, found := watcher.config.Watch[host]; !found {
+		return []xresolver.Route{}, errors.New(host + " is not part of the consul listener")
+	}
+	return watcher.balancers[watcher.config.Watch[host]].Get()
+}

--- a/xresolver/consul/consullistener_test.go
+++ b/xresolver/consul/consullistener_test.go
@@ -1,0 +1,78 @@
+package consul
+
+import (
+	"fmt"
+	"github.com/Comcast/webpa-common/service/monitor"
+	"github.com/Comcast/webpa-common/xresolver"
+	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestConsulWatcher(t *testing.T) {
+	assert := assert.New(t)
+
+	customhost := "custom.host.com"
+	customport := "8080"
+	service := "custom"
+	expectedBody := "Hello World\n"
+
+	//customInstance := "custom.host-A.com"
+
+	serverA := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "a"+expectedBody)
+	}))
+	defer serverA.Close()
+
+	serverB := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "b"+expectedBody)
+	}))
+	defer serverB.Close()
+
+	watcher := NewConsulWatcher(&Options{
+		Watch: map[string]string{customhost: service},
+	})
+
+	watcher.MonitorEvent(monitor.Event{
+		Key:       service + "[tag tagA]" + "{passingOnly=true}",
+		Instances: []string{serverA.URL, serverB.URL},
+	})
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			DialContext:       xresolver.NewResolver(nil, watcher).DialContext,
+			DisableKeepAlives: true,
+		},
+	}
+
+	req, err := http.NewRequest("GET", "http://"+net.JoinHostPort(customhost, customport), nil)
+	assert.NoError(err)
+
+	res, err := client.Do(req)
+	if assert.NoError(err) {
+
+		body, err := ioutil.ReadAll(res.Body)
+		res.Body.Close()
+		assert.NoError(err)
+
+		assert.Equal(200, res.StatusCode)
+		assert.Equal("a"+expectedBody, string(body))
+	}
+
+	req, err = http.NewRequest("GET", "http://"+net.JoinHostPort(customhost, customport), nil)
+	assert.NoError(err)
+
+	res, err = client.Do(req)
+	if assert.NoError(err) {
+
+		body, err := ioutil.ReadAll(res.Body)
+		res.Body.Close()
+		assert.NoError(err)
+
+		assert.Equal(200, res.StatusCode)
+		assert.Equal("b"+expectedBody, string(body))
+	}
+}

--- a/xresolver/consul/consullistener_test.go
+++ b/xresolver/consul/consullistener_test.go
@@ -32,7 +32,7 @@ func TestConsulWatcher(t *testing.T) {
 	}))
 	defer serverB.Close()
 
-	watcher := NewConsulWatcher(&Options{
+	watcher := NewConsulWatcher(Options{
 		Watch: map[string]string{customhost: service},
 	})
 

--- a/xresolver/consul/consullistener_test.go
+++ b/xresolver/consul/consullistener_test.go
@@ -44,7 +44,7 @@ func TestConsulWatcher(t *testing.T) {
 
 	client := &http.Client{
 		Transport: &http.Transport{
-			DialContext: xresolver.NewResolver(nil, watcher).DialContext,
+			DialContext: xresolver.NewResolver(xresolver.DefaultDialer, watcher).DialContext,
 			// note: DisableKeepAlives is required so when we do the request again we don't reuse the same connection.
 			DisableKeepAlives: true,
 		},

--- a/xresolver/consul/consullistener_test.go
+++ b/xresolver/consul/consullistener_test.go
@@ -36,6 +36,7 @@ func TestConsulWatcher(t *testing.T) {
 		Watch: map[string]string{customhost: service},
 	})
 
+	// note: MonitorEvent is Listen interface in the monitor package
 	watcher.MonitorEvent(monitor.Event{
 		Key:       service + "[tag tagA]" + "{passingOnly=true}",
 		Instances: []string{serverA.URL, serverB.URL},
@@ -43,7 +44,8 @@ func TestConsulWatcher(t *testing.T) {
 
 	client := &http.Client{
 		Transport: &http.Transport{
-			DialContext:       xresolver.NewResolver(nil, watcher).DialContext,
+			DialContext: xresolver.NewResolver(nil, watcher).DialContext,
+			// note: DisableKeepAlives is required so when we do the request again we don't reuse the same connection.
 			DisableKeepAlives: true,
 		},
 	}

--- a/xresolver/types.go
+++ b/xresolver/types.go
@@ -1,0 +1,134 @@
+package xresolver
+
+import (
+	"context"
+	"errors"
+	"net"
+	"sync"
+)
+
+type Lookup interface {
+	// LookupIPAddr looks up host using the local resolver. It returns a slice of that host's IPv4 and IPv6 addresses.
+	LookupIPAddr(ctx context.Context, host string) ([]net.IPAddr, error)
+}
+
+type Dial interface {
+	// DialContext connects to the address on the named network using the provided context.
+	DialContext(ctx context.Context, network, addr string) (con net.Conn, err error)
+}
+
+type ConnCreation interface {
+	Dial(network, address string) (net.Conn, error)
+}
+
+// Resolver represents how to generate the address and how to create the connection
+type Resolver interface {
+	Dial
+
+	// Add adds the resolver to the methods of creating the IPv4 and IPv6 addresses
+	Add(r Lookup) error
+
+	// Remove removes the resolver to the methods of creating the IPv4 and IPv6 addresses
+	Remove(r Lookup) error
+}
+
+type orderedIP struct {
+	ip    net.IPAddr
+	index int
+}
+
+type RoundRobin struct {
+	lock *sync.RWMutex
+	ips  map[string]*orderedIP
+}
+
+func NewRoundRobinBalancer() *RoundRobin {
+	return &RoundRobin{
+		lock: new(sync.RWMutex),
+		ips:  make(map[string]*orderedIP, 0),
+	}
+}
+
+func (robin *RoundRobin) Add(addr net.IPAddr) error {
+	// check if exist
+	robin.lock.RLock()
+	if _, found := robin.ips[addr.String()]; found {
+		robin.lock.RUnlock()
+		return errors.New("addr already in rotation")
+	}
+	robin.lock.RUnlock()
+
+	// Add to our structure
+	robin.lock.Lock()
+	defer robin.lock.Unlock()
+	robin.ips[addr.String()] = &orderedIP{
+		ip:    addr,
+		index: len(robin.ips),
+	}
+	return nil
+}
+
+func (robin *RoundRobin) Remove(addr net.IPAddr) error {
+	robin.lock.RLock()
+	if _, found := robin.ips[addr.String()]; !found {
+		robin.lock.RUnlock()
+		return errors.New("addr not found")
+	}
+	defer func() {
+		robin.lock.RUnlock()
+
+		robin.lock.Lock()
+		defer robin.lock.Unlock()
+		// remove it
+		deletedIP := robin.ips[addr.String()]
+		delete(robin.ips, addr.String())
+
+		// update order
+		if len(robin.ips) == 0 {
+			return
+		}
+
+		for _, ip := range robin.ips {
+			if ip.index < deletedIP.index {
+				continue
+			}
+			ip.index = ip.index - 1
+		}
+	}()
+
+	return nil
+
+}
+
+func (robin *RoundRobin) Get() ([]net.IPAddr, error) {
+	robin.lock.RLock()
+
+	records := make([]net.IPAddr, len(robin.ips))
+	if len(robin.ips) == 0 {
+		robin.lock.RUnlock()
+		return records, errors.New("no records available")
+	}
+
+	for _, ip := range robin.ips {
+		records[ip.index] = ip.ip
+	}
+
+	// update order
+	defer func() {
+		robin.lock.RUnlock()
+
+		robin.lock.Lock()
+		defer robin.lock.Unlock()
+		size := len(robin.ips)
+
+		for _, ip := range robin.ips {
+			if ip.index == 0 {
+				ip.index = size - 1
+				continue
+			}
+			ip.index = ip.index - 1
+		}
+	}()
+
+	return records, nil
+}

--- a/xresolver/types_test.go
+++ b/xresolver/types_test.go
@@ -5,21 +5,30 @@ import (
 	"fmt"
 	"github.com/stretchr/testify/assert"
 	"math"
-	"net"
 	"strconv"
 	"testing"
 )
+
+func testRoute(ip string) Route {
+	return Route{
+		Host:   ip,
+		Scheme: "http",
+	}
+}
 
 func TestRoundRobinOperations(t *testing.T) {
 	assert := assert.New(t)
 
 	balancer := NewRoundRobinBalancer()
 
-	expected := net.IPAddr{IP: net.ParseIP("127.0.0.1")}
+	expected := testRoute("127.0.0.1")
 
 	records, err := balancer.Get()
 	assert.Error(err)
 	assert.Empty(records)
+
+	err = balancer.Remove(expected)
+	assert.Error(err)
 
 	err = balancer.Add(expected)
 	assert.NoError(err)
@@ -38,6 +47,23 @@ func TestRoundRobinOperations(t *testing.T) {
 	records, err = balancer.Get()
 	assert.Error(err)
 	assert.Empty(records)
+
+	balancer.Update([]Route{
+		expected,
+		testRoute("127.0.0.1"),
+		testRoute("8.8.8.8"),
+		testRoute("1.1.1.1"),
+		testRoute("127.0.0.1"),
+	})
+
+	records, err = balancer.Get()
+	assert.NoError(err)
+	assert.Equal(3, len(records))
+	assert.Equal([]Route{
+		expected,
+		testRoute("8.8.8.8"),
+		testRoute("1.1.1.1"),
+	}, records)
 }
 
 func TestRoundRobinOrder(t *testing.T) {
@@ -45,9 +71,9 @@ func TestRoundRobinOrder(t *testing.T) {
 
 	balancer := NewRoundRobinBalancer()
 
-	localAddress := net.IPAddr{IP: net.ParseIP("127.0.0.1")}
-	googleAddres := net.IPAddr{IP: net.ParseIP("8.8.8.8")}
-	addressOnes := net.IPAddr{IP: net.ParseIP("1.1.1.1")}
+	localAddress := testRoute("127.0.0.1")
+	googleAddres := testRoute("8.8.8.8")
+	addressOnes := testRoute("1.1.1.1")
 
 	balancer.Add(localAddress)
 	balancer.Add(googleAddres)
@@ -55,22 +81,22 @@ func TestRoundRobinOrder(t *testing.T) {
 
 	records, err := balancer.Get()
 	assert.NoError(err)
-	assert.Equal([]net.IPAddr{localAddress, googleAddres, addressOnes}, records, "records are assumed to be the order in which added")
+	assert.Equal([]Route{localAddress, googleAddres, addressOnes}, records, "records are assumed to be the order in which added")
 
 	records, err = balancer.Get()
 	assert.NoError(err)
-	assert.Equal([]net.IPAddr{googleAddres, addressOnes, localAddress}, records, "records should rotate on another Get()")
+	assert.Equal([]Route{googleAddres, addressOnes, localAddress}, records, "records should rotate on another Get()")
 
 	records, err = balancer.Get()
 	assert.NoError(err)
-	assert.Equal([]net.IPAddr{addressOnes, localAddress, googleAddres}, records, "records should rotate on another Get()")
+	assert.Equal([]Route{addressOnes, localAddress, googleAddres}, records, "records should rotate on another Get()")
 
 	err = balancer.Remove(googleAddres)
 	assert.NoError(err)
 
 	records, err = balancer.Get()
 	assert.NoError(err)
-	assert.Equal([]net.IPAddr{localAddress, addressOnes}, records, "records should rotate on another Get()")
+	assert.Equal([]Route{localAddress, addressOnes}, records, "records should rotate on another Get()")
 }
 
 /**
@@ -82,17 +108,17 @@ L3 Cache: 6 MB
 Memory: 16 GB
 Version: OS X 10.13.5
 
-BenchmarkRoundRobinAdd/add/1-8         	10000000	       213 ns/op	      40 B/op	       3 allocs/op
-BenchmarkRoundRobinAdd/add/2-8         	 3000000	       430 ns/op	      80 B/op	       6 allocs/op
-BenchmarkRoundRobinAdd/add/4-8         	 2000000	       945 ns/op	     160 B/op	      12 allocs/op
-BenchmarkRoundRobinAdd/add/8-8         	 1000000	      2224 ns/op	     320 B/op	      24 allocs/op
-BenchmarkRoundRobinAdd/add/16-8        	  300000	      3879 ns/op	     640 B/op	      48 allocs/op
-BenchmarkRoundRobinAdd/add/32-8        	  200000	      8129 ns/op	    1280 B/op	      96 allocs/op
-BenchmarkRoundRobinAdd/add/64-8        	  100000	     16227 ns/op	    2560 B/op	     192 allocs/op
-BenchmarkRoundRobinAdd/add/128-8       	   50000	     33005 ns/op	    5344 B/op	     412 allocs/op
-BenchmarkRoundRobinAdd/add/256-8       	   20000	     67932 ns/op	   11490 B/op	     924 allocs/op
-BenchmarkRoundRobinAdd/add/512-8       	   10000	    137234 ns/op	   22984 B/op	    1848 allocs/op
-BenchmarkRoundRobinAdd/add/1024-8      	    5000	    285058 ns/op	   45985 B/op	    3696 allocs/op
+BenchmarkRoundRobinAdd/add/1-8         	10000000	       237 ns/op	      40 B/op	       3 allocs/op
+BenchmarkRoundRobinAdd/add/2-8         	 3000000	       440 ns/op	      80 B/op	       6 allocs/op
+BenchmarkRoundRobinAdd/add/4-8         	 2000000	       880 ns/op	     160 B/op	      12 allocs/op
+BenchmarkRoundRobinAdd/add/8-8         	 1000000	      1782 ns/op	     320 B/op	      24 allocs/op
+BenchmarkRoundRobinAdd/add/16-8        	  300000	      3628 ns/op	     640 B/op	      48 allocs/op
+BenchmarkRoundRobinAdd/add/32-8        	  200000	      7217 ns/op	    1280 B/op	      96 allocs/op
+BenchmarkRoundRobinAdd/add/64-8        	  100000	     14479 ns/op	    2560 B/op	     192 allocs/op
+BenchmarkRoundRobinAdd/add/128-8       	   50000	     30517 ns/op	    5344 B/op	     412 allocs/op
+BenchmarkRoundRobinAdd/add/256-8       	   20000	     62290 ns/op	   11490 B/op	     924 allocs/op
+BenchmarkRoundRobinAdd/add/512-8       	   10000	    121836 ns/op	   22984 B/op	    1848 allocs/op
+BenchmarkRoundRobinAdd/add/1024-8      	    5000	    248794 ns/op	   45986 B/op	    3696 allocs/op
 */
 
 func BenchmarkRoundRobinAdd(b *testing.B) {
@@ -105,13 +131,12 @@ func BenchmarkRoundRobinAdd(b *testing.B) {
 
 			for i := 0; i < b.N; i++ {
 				for index := 0; index < n; index++ {
-					balancer.Add(net.IPAddr{IP: IPv4Address(int64(index))})
+					balancer.Add(testRoute(IPv4Address(int64(index))))
 				}
 			}
 		})
 	}
 }
-
 
 /**
 Processor Speed: 2.8 GHz
@@ -122,17 +147,18 @@ L3 Cache: 6 MB
 Memory: 16 GB
 Version: OS X 10.13.5
 
-BenchmarkRoundRobinRemove/remove/1-8   	 2000000	       873 ns/op	      32 B/op	       3 allocs/op
-BenchmarkRoundRobinRemove/remove/2-8   	 1000000	      1228 ns/op	      48 B/op	       6 allocs/op
-BenchmarkRoundRobinRemove/remove/4-8   	 1000000	      1935 ns/op	      96 B/op	      12 allocs/op
-BenchmarkRoundRobinRemove/remove/8-8   	  500000	      3525 ns/op	     192 B/op	      24 allocs/op
-BenchmarkRoundRobinRemove/remove/16-8  	  200000	      8811 ns/op	     384 B/op	      48 allocs/op
-BenchmarkRoundRobinRemove/remove/32-8  	  100000	     22149 ns/op	     768 B/op	      96 allocs/op
-BenchmarkRoundRobinRemove/remove/64-8  	   20000	     64724 ns/op	    1536 B/op	     192 allocs/op
-BenchmarkRoundRobinRemove/remove/128-8 	   10000	    207113 ns/op	    3744 B/op	     384 allocs/op
-BenchmarkRoundRobinRemove/remove/256-8 	    2000	    782009 ns/op	    9888 B/op	     768 allocs/op
-BenchmarkRoundRobinRemove/remove/512-8 	     500	   2855754 ns/op	   19776 B/op	    1536 allocs/op
-BenchmarkRoundRobinRemove/remove/1024-8      100	  10627272 ns/op	   39552 B/op	    3072 allocs/op
+BenchmarkRoundRobinRemove/remove/1-8   	 1000000	      1206 ns/op	      48 B/op	       3 allocs/op
+BenchmarkRoundRobinRemove/remove/2-8   	 1000000	      1685 ns/op	      96 B/op	       6 allocs/op
+BenchmarkRoundRobinRemove/remove/4-8   	  500000	      2411 ns/op	     192 B/op	      12 allocs/op
+BenchmarkRoundRobinRemove/remove/8-8   	  300000	      4299 ns/op	     384 B/op	      24 allocs/op
+BenchmarkRoundRobinRemove/remove/16-8  	  200000	      9864 ns/op	     768 B/op	      48 allocs/op
+BenchmarkRoundRobinRemove/remove/32-8  	   50000	     24964 ns/op	    1536 B/op	      96 allocs/op
+BenchmarkRoundRobinRemove/remove/64-8  	   20000	     66353 ns/op	    3072 B/op	     192 allocs/op
+BenchmarkRoundRobinRemove/remove/128-8 	   10000	    213464 ns/op	    6144 B/op	     384 allocs/op
+BenchmarkRoundRobinRemove/remove/256-8 	    2000	    737753 ns/op	   12288 B/op	     768 allocs/op
+BenchmarkRoundRobinRemove/remove/512-8 	     500	   2773625 ns/op	   24576 B/op	    1536 allocs/op
+BenchmarkRoundRobinRemove/remove/1024-8      100	  10768748 ns/op	   49152 B/op	    3072 allocs/op
+
 */
 
 func BenchmarkRoundRobinRemove(b *testing.B) {
@@ -140,20 +166,20 @@ func BenchmarkRoundRobinRemove(b *testing.B) {
 		n := int(math.Pow(2, k))
 		b.Run(fmt.Sprintf("remove/%d", n), func(b *testing.B) {
 			b.ReportAllocs()
-
 			balancer := NewRoundRobinBalancer()
+			b.ResetTimer()
 
 			for i := 0; i < b.N; i++ {
 				b.StopTimer()
-				records := make([]net.IP, n)
+				records := make([]string, n)
 				for index := 0; index < n; index++ {
 					ip := IPv4Address(int64(index))
 					records[index] = ip
-					balancer.Add(net.IPAddr{IP: ip})
+					balancer.Add(testRoute(ip))
 				}
 				b.StartTimer()
 				for index := 0; index < n; index++ {
-					err := balancer.Remove(net.IPAddr{IP: records[index]})
+					err := balancer.Remove(testRoute(records[index]))
 					if err != nil {
 						panic(err)
 					}
@@ -163,6 +189,49 @@ func BenchmarkRoundRobinRemove(b *testing.B) {
 	}
 }
 
+/**
+Processor Speed: 2.8 GHz
+Number of Processors: 1
+Total Number of Cores: 4
+L2 Cache (per Core): 256 KB
+L3 Cache: 6 MB
+Memory: 16 GB
+Version: OS X 10.13.5
+
+BenchmarkRoundRobinUpdate/update/1-8             1000000              1460 ns/op             336 B/op          5 allocs/op
+BenchmarkRoundRobinUpdate/update/2-8             1000000              1780 ns/op             416 B/op          8 allocs/op
+BenchmarkRoundRobinUpdate/update/4-8             1000000              2268 ns/op             576 B/op         14 allocs/op
+BenchmarkRoundRobinUpdate/update/8-8              500000              3352 ns/op             896 B/op         26 allocs/op
+BenchmarkRoundRobinUpdate/update/16-8             200000              7246 ns/op            2909 B/op         52 allocs/op
+BenchmarkRoundRobinUpdate/update/32-8             100000             11500 ns/op            6148 B/op        102 allocs/op
+BenchmarkRoundRobinUpdate/update/64-8             100000             22976 ns/op           13140 B/op        201 allocs/op
+BenchmarkRoundRobinUpdate/update/128-8             30000             43134 ns/op           26565 B/op        395 allocs/op
+BenchmarkRoundRobinUpdate/update/256-8             20000             82270 ns/op           51227 B/op        780 allocs/op
+BenchmarkRoundRobinUpdate/update/512-8             10000            166695 ns/op          102301 B/op       1558 allocs/op
+BenchmarkRoundRobinUpdate/update/1024-8             5000            332736 ns/op          204300 B/op       3113 allocs/op
+*/
+
+func BenchmarkRoundRobinUpdate(b *testing.B) {
+	for k := 0.; k <= 10; k++ {
+		n := int(math.Pow(2, k))
+		b.Run(fmt.Sprintf("update/%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			balancer := NewRoundRobinBalancer()
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				routes := make([]Route, n)
+				for index := 0; index < n; index++ {
+					routes[index] = testRoute(IPv4Address(int64(index)))
+				}
+				b.StartTimer()
+
+				balancer.Update(routes)
+			}
+		})
+	}
+}
 
 /**
 Processor Speed: 2.8 GHz
@@ -173,17 +242,17 @@ L3 Cache: 6 MB
 Memory: 16 GB
 Version: OS X 10.13.5
 
-BenchmarkRoundRobinGet/get/1-8                  	10000000	       234 ns/op	      48 B/op	       1 allocs/op
-BenchmarkRoundRobinGet/get/2-8                  	 5000000	       285 ns/op	      80 B/op	       1 allocs/op
-BenchmarkRoundRobinGet/get/4-8                  	 5000000	       358 ns/op	     160 B/op	       1 allocs/op
-BenchmarkRoundRobinGet/get/8-8                  	 3000000	       460 ns/op	     320 B/op	       1 allocs/op
-BenchmarkRoundRobinGet/get/16-8                 	 2000000	       810 ns/op	     640 B/op	       1 allocs/op
-BenchmarkRoundRobinGet/get/32-8                 	 1000000	      1497 ns/op	    1280 B/op	       1 allocs/op
-BenchmarkRoundRobinGet/get/64-8                 	  500000	      2683 ns/op	    2688 B/op	       1 allocs/op
-BenchmarkRoundRobinGet/get/128-8                	  300000	      5052 ns/op	    5376 B/op	       1 allocs/op
-BenchmarkRoundRobinGet/get/256-8                	  200000	     10742 ns/op	   10240 B/op	       1 allocs/op
-BenchmarkRoundRobinGet/get/512-8                	  100000	     19537 ns/op	   20480 B/op	       1 allocs/op
-BenchmarkRoundRobinGet/get/1024-8               	   50000	     39192 ns/op	   40960 B/op	       1 allocs/op
+BenchmarkRoundRobinGet/get/1-8                  	10000000	       231 ns/op	      48 B/op	       1 allocs/op
+BenchmarkRoundRobinGet/get/2-8                  	 5000000	       282 ns/op	      80 B/op	       1 allocs/op
+BenchmarkRoundRobinGet/get/4-8                  	 5000000	       349 ns/op	     160 B/op	       1 allocs/op
+BenchmarkRoundRobinGet/get/8-8                  	 3000000	       436 ns/op	     320 B/op	       1 allocs/op
+BenchmarkRoundRobinGet/get/16-8                 	 2000000	       786 ns/op	     640 B/op	       1 allocs/op
+BenchmarkRoundRobinGet/get/32-8                 	 1000000	      1402 ns/op	    1280 B/op	       1 allocs/op
+BenchmarkRoundRobinGet/get/64-8                 	  500000	      2615 ns/op	    2688 B/op	       1 allocs/op
+BenchmarkRoundRobinGet/get/128-8                	  300000	      5121 ns/op	    5376 B/op	       1 allocs/op
+BenchmarkRoundRobinGet/get/256-8                	  200000	      9817 ns/op	   10240 B/op	       1 allocs/op
+BenchmarkRoundRobinGet/get/512-8                	  100000	     19733 ns/op	   20480 B/op	       1 allocs/op
+BenchmarkRoundRobinGet/get/1024-8               	   50000	     44176 ns/op	   40960 B/op	       1 allocs/op
 */
 
 func BenchmarkRoundRobinGet(b *testing.B) {
@@ -194,7 +263,7 @@ func BenchmarkRoundRobinGet(b *testing.B) {
 
 			balancer := NewRoundRobinBalancer()
 			for index := 0; index < n; index++ {
-				balancer.Add(net.IPAddr{IP: IPv4Address(int64(index))})
+				balancer.Add(testRoute(IPv4Address(int64(index))))
 			}
 
 			b.ResetTimer()
@@ -209,12 +278,12 @@ func BenchmarkRoundRobinGet(b *testing.B) {
 	}
 }
 
-func IPv4Address(ipInt int64) net.IP {
+func IPv4Address(ipInt int64) string {
 	// need to do two bit shifting and “0xff” masking
 	b0 := strconv.FormatInt((ipInt>>24)&0xff, 10)
 	b1 := strconv.FormatInt((ipInt>>16)&0xff, 10)
 	b2 := strconv.FormatInt((ipInt>>8)&0xff, 10)
 	b3 := strconv.FormatInt((ipInt & 0xff), 10)
 
-	return net.ParseIP(b0 + "." + b1 + "." + b2 + "." + b3)
+	return b0 + "." + b1 + "." + b2 + "." + b3
 }

--- a/xresolver/types_test.go
+++ b/xresolver/types_test.go
@@ -1,0 +1,220 @@
+package xresolver
+
+import (
+	"errors"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"math"
+	"net"
+	"strconv"
+	"testing"
+)
+
+func TestRoundRobinOperations(t *testing.T) {
+	assert := assert.New(t)
+
+	balancer := NewRoundRobinBalancer()
+
+	expected := net.IPAddr{IP: net.ParseIP("127.0.0.1")}
+
+	records, err := balancer.Get()
+	assert.Error(err)
+	assert.Empty(records)
+
+	err = balancer.Add(expected)
+	assert.NoError(err)
+
+	err = balancer.Add(expected)
+	assert.Error(err)
+
+	records, err = balancer.Get()
+	assert.NoError(err)
+	assert.Equal(1, len(records))
+	assert.Equal(expected, records[0])
+
+	err = balancer.Remove(expected)
+	assert.NoError(err)
+
+	records, err = balancer.Get()
+	assert.Error(err)
+	assert.Empty(records)
+}
+
+func TestRoundRobinOrder(t *testing.T) {
+	assert := assert.New(t)
+
+	balancer := NewRoundRobinBalancer()
+
+	localAddress := net.IPAddr{IP: net.ParseIP("127.0.0.1")}
+	googleAddres := net.IPAddr{IP: net.ParseIP("8.8.8.8")}
+	addressOnes := net.IPAddr{IP: net.ParseIP("1.1.1.1")}
+
+	balancer.Add(localAddress)
+	balancer.Add(googleAddres)
+	balancer.Add(addressOnes)
+
+	records, err := balancer.Get()
+	assert.NoError(err)
+	assert.Equal([]net.IPAddr{localAddress, googleAddres, addressOnes}, records, "records are assumed to be the order in which added")
+
+	records, err = balancer.Get()
+	assert.NoError(err)
+	assert.Equal([]net.IPAddr{googleAddres, addressOnes, localAddress}, records, "records should rotate on another Get()")
+
+	records, err = balancer.Get()
+	assert.NoError(err)
+	assert.Equal([]net.IPAddr{addressOnes, localAddress, googleAddres}, records, "records should rotate on another Get()")
+
+	err = balancer.Remove(googleAddres)
+	assert.NoError(err)
+
+	records, err = balancer.Get()
+	assert.NoError(err)
+	assert.Equal([]net.IPAddr{localAddress, addressOnes}, records, "records should rotate on another Get()")
+}
+
+/**
+Processor Speed: 2.8 GHz
+Number of Processors: 1
+Total Number of Cores: 4
+L2 Cache (per Core): 256 KB
+L3 Cache: 6 MB
+Memory: 16 GB
+Version: OS X 10.13.5
+
+BenchmarkRoundRobinAdd/add/1-8         	10000000	       213 ns/op	      40 B/op	       3 allocs/op
+BenchmarkRoundRobinAdd/add/2-8         	 3000000	       430 ns/op	      80 B/op	       6 allocs/op
+BenchmarkRoundRobinAdd/add/4-8         	 2000000	       945 ns/op	     160 B/op	      12 allocs/op
+BenchmarkRoundRobinAdd/add/8-8         	 1000000	      2224 ns/op	     320 B/op	      24 allocs/op
+BenchmarkRoundRobinAdd/add/16-8        	  300000	      3879 ns/op	     640 B/op	      48 allocs/op
+BenchmarkRoundRobinAdd/add/32-8        	  200000	      8129 ns/op	    1280 B/op	      96 allocs/op
+BenchmarkRoundRobinAdd/add/64-8        	  100000	     16227 ns/op	    2560 B/op	     192 allocs/op
+BenchmarkRoundRobinAdd/add/128-8       	   50000	     33005 ns/op	    5344 B/op	     412 allocs/op
+BenchmarkRoundRobinAdd/add/256-8       	   20000	     67932 ns/op	   11490 B/op	     924 allocs/op
+BenchmarkRoundRobinAdd/add/512-8       	   10000	    137234 ns/op	   22984 B/op	    1848 allocs/op
+BenchmarkRoundRobinAdd/add/1024-8      	    5000	    285058 ns/op	   45985 B/op	    3696 allocs/op
+*/
+
+func BenchmarkRoundRobinAdd(b *testing.B) {
+	for k := 0.; k <= 10; k++ {
+		n := int(math.Pow(2, k))
+		b.Run(fmt.Sprintf("add/%d", n), func(b *testing.B) {
+			balancer := NewRoundRobinBalancer()
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				for index := 0; index < n; index++ {
+					balancer.Add(net.IPAddr{IP: IPv4Address(int64(index))})
+				}
+			}
+		})
+	}
+}
+
+
+/**
+Processor Speed: 2.8 GHz
+Number of Processors: 1
+Total Number of Cores: 4
+L2 Cache (per Core): 256 KB
+L3 Cache: 6 MB
+Memory: 16 GB
+Version: OS X 10.13.5
+
+BenchmarkRoundRobinRemove/remove/1-8   	 2000000	       873 ns/op	      32 B/op	       3 allocs/op
+BenchmarkRoundRobinRemove/remove/2-8   	 1000000	      1228 ns/op	      48 B/op	       6 allocs/op
+BenchmarkRoundRobinRemove/remove/4-8   	 1000000	      1935 ns/op	      96 B/op	      12 allocs/op
+BenchmarkRoundRobinRemove/remove/8-8   	  500000	      3525 ns/op	     192 B/op	      24 allocs/op
+BenchmarkRoundRobinRemove/remove/16-8  	  200000	      8811 ns/op	     384 B/op	      48 allocs/op
+BenchmarkRoundRobinRemove/remove/32-8  	  100000	     22149 ns/op	     768 B/op	      96 allocs/op
+BenchmarkRoundRobinRemove/remove/64-8  	   20000	     64724 ns/op	    1536 B/op	     192 allocs/op
+BenchmarkRoundRobinRemove/remove/128-8 	   10000	    207113 ns/op	    3744 B/op	     384 allocs/op
+BenchmarkRoundRobinRemove/remove/256-8 	    2000	    782009 ns/op	    9888 B/op	     768 allocs/op
+BenchmarkRoundRobinRemove/remove/512-8 	     500	   2855754 ns/op	   19776 B/op	    1536 allocs/op
+BenchmarkRoundRobinRemove/remove/1024-8      100	  10627272 ns/op	   39552 B/op	    3072 allocs/op
+*/
+
+func BenchmarkRoundRobinRemove(b *testing.B) {
+	for k := 0.; k <= 10; k++ {
+		n := int(math.Pow(2, k))
+		b.Run(fmt.Sprintf("remove/%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+
+			balancer := NewRoundRobinBalancer()
+
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				records := make([]net.IP, n)
+				for index := 0; index < n; index++ {
+					ip := IPv4Address(int64(index))
+					records[index] = ip
+					balancer.Add(net.IPAddr{IP: ip})
+				}
+				b.StartTimer()
+				for index := 0; index < n; index++ {
+					err := balancer.Remove(net.IPAddr{IP: records[index]})
+					if err != nil {
+						panic(err)
+					}
+				}
+			}
+		})
+	}
+}
+
+
+/**
+Processor Speed: 2.8 GHz
+Number of Processors: 1
+Total Number of Cores: 4
+L2 Cache (per Core): 256 KB
+L3 Cache: 6 MB
+Memory: 16 GB
+Version: OS X 10.13.5
+
+BenchmarkRoundRobinGet/get/1-8                  	10000000	       234 ns/op	      48 B/op	       1 allocs/op
+BenchmarkRoundRobinGet/get/2-8                  	 5000000	       285 ns/op	      80 B/op	       1 allocs/op
+BenchmarkRoundRobinGet/get/4-8                  	 5000000	       358 ns/op	     160 B/op	       1 allocs/op
+BenchmarkRoundRobinGet/get/8-8                  	 3000000	       460 ns/op	     320 B/op	       1 allocs/op
+BenchmarkRoundRobinGet/get/16-8                 	 2000000	       810 ns/op	     640 B/op	       1 allocs/op
+BenchmarkRoundRobinGet/get/32-8                 	 1000000	      1497 ns/op	    1280 B/op	       1 allocs/op
+BenchmarkRoundRobinGet/get/64-8                 	  500000	      2683 ns/op	    2688 B/op	       1 allocs/op
+BenchmarkRoundRobinGet/get/128-8                	  300000	      5052 ns/op	    5376 B/op	       1 allocs/op
+BenchmarkRoundRobinGet/get/256-8                	  200000	     10742 ns/op	   10240 B/op	       1 allocs/op
+BenchmarkRoundRobinGet/get/512-8                	  100000	     19537 ns/op	   20480 B/op	       1 allocs/op
+BenchmarkRoundRobinGet/get/1024-8               	   50000	     39192 ns/op	   40960 B/op	       1 allocs/op
+*/
+
+func BenchmarkRoundRobinGet(b *testing.B) {
+	for k := 0.; k <= 10; k++ {
+		n := int(math.Pow(2, k))
+		b.Run(fmt.Sprintf("get/%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+
+			balancer := NewRoundRobinBalancer()
+			for index := 0; index < n; index++ {
+				balancer.Add(net.IPAddr{IP: IPv4Address(int64(index))})
+			}
+
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				records, _ := balancer.Get()
+				if len(records) == 0 {
+					b.Fatal(errors.New("no records"))
+				}
+			}
+		})
+	}
+}
+
+func IPv4Address(ipInt int64) net.IP {
+	// need to do two bit shifting and “0xff” masking
+	b0 := strconv.FormatInt((ipInt>>24)&0xff, 10)
+	b1 := strconv.FormatInt((ipInt>>16)&0xff, 10)
+	b2 := strconv.FormatInt((ipInt>>8)&0xff, 10)
+	b3 := strconv.FormatInt((ipInt & 0xff), 10)
+
+	return net.ParseIP(b0 + "." + b1 + "." + b2 + "." + b3)
+}

--- a/xresolver/xresolver.go
+++ b/xresolver/xresolver.go
@@ -1,0 +1,127 @@
+package xresolver
+
+import (
+	"context"
+	"errors"
+	"net"
+	"sync"
+)
+
+// Note to self: Dial is not being set for net.Resolver because that is the Dial to the DNS server.
+
+type Lookup interface {
+	// LookupIPAddr looks up host using the local resolver. It returns a slice of that host's IPv4 and IPv6 addresses.
+	LookupIPAddr(ctx context.Context, host string) ([]net.IPAddr, error)
+}
+
+type Dial interface {
+	// DialContext connects to the address on the named network using the provided context.
+	DialContext(ctx context.Context, network, addr string) (con net.Conn, err error)
+}
+
+type ConnCreation interface {
+	Dial(network, address string) (net.Conn, error)
+}
+
+// Resolver represents how to generate the address and how to create the connection
+type Resolver interface {
+	Dial
+
+	// Add adds the resolver to the methods of creating the IPv4 and IPv6 addresses
+	Add(r Lookup) error
+
+	// Remove removes the resolver to the methods of creating the IPv4 and IPv6 addresses
+	Remove(r Lookup) error
+}
+
+var DefaultDialer = &net.Dialer{}
+
+type resolver struct {
+	resolvers map[Lookup]struct{}
+	lock      *sync.RWMutex
+	dialer    *net.Dialer
+}
+
+func NewResolver(dialer *net.Dialer) Resolver {
+	if dialer == nil {
+		dialer = DefaultDialer
+	}
+	return &resolver{
+		resolvers: map[Lookup]struct{}{net.DefaultResolver: {}},
+		lock:      new(sync.RWMutex),
+		dialer:    dialer,
+	}
+}
+
+func (resolve *resolver) Add(r Lookup) error {
+	resolve.lock.RLock()
+	_, found := resolve.resolvers[r]
+	resolve.lock.RUnlock()
+	if found {
+		return errors.New("resolver already exist")
+	}
+
+	resolve.lock.Lock()
+	defer resolve.lock.Unlock()
+	resolve.resolvers[r] = struct{}{}
+	return nil
+}
+
+func (resolve *resolver) Remove(r Lookup) error {
+	resolve.lock.RLock()
+	_, found := resolve.resolvers[r]
+	resolve.lock.RUnlock()
+	if !found {
+		return errors.New("resolver does not exist")
+	}
+
+	resolve.lock.Lock()
+	defer resolve.lock.Unlock()
+	delete(resolve.resolvers, r)
+	return nil
+}
+
+func (resolve *resolver) getRecords(ctx context.Context, host string) []net.IPAddr {
+	records := make([]net.IPAddr, 0)
+	for r := range resolve.resolvers {
+		tempRecords, err := r.LookupIPAddr(ctx, host)
+		if err == nil {
+			records = append(records, tempRecords...)
+		}
+	}
+
+	return records
+}
+
+func (resolve *resolver) DialContext(ctx context.Context, network, addr string) (con net.Conn, err error) {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, err
+	}
+	ip := net.ParseIP(host)
+	if ip != nil {
+		return resolve.dialer.Dial(network, net.JoinHostPort(ip.String(), port))
+	}
+
+	// get records using custom resolvers
+	records := resolve.getRecords(ctx, host)
+
+	// generate Con or err from records
+	con, err = resolve.createConnection(records, network, port)
+	if err == nil {
+		return
+	}
+
+	// if no connection is create use the default dialer
+	return resolve.dialer.DialContext(ctx, network, addr)
+}
+
+func (resolve *resolver) createConnection(records []net.IPAddr, network, port string) (con net.Conn, err error) {
+	for _, item := range records {
+		con, err = resolve.dialer.Dial(network, net.JoinHostPort(item.IP.String(), port))
+		if err == nil {
+			return
+		}
+	}
+	return nil, errors.New("failed to create connection from records")
+}

--- a/xresolver/xresolver.go
+++ b/xresolver/xresolver.go
@@ -10,18 +10,15 @@ import (
 
 // Note to self: Dial is not being set for net.Resolver because that is the Dial to the DNS server.
 
-var DefaultDialer = &net.Dialer{}
+var DefaultDialer = net.Dialer{}
 
 type resolver struct {
 	resolvers map[Lookup]bool
 	lock      sync.RWMutex
-	dialer    *net.Dialer
+	dialer    net.Dialer
 }
 
-func NewResolver(dialer *net.Dialer, lookups ...Lookup) Resolver {
-	if dialer == nil {
-		dialer = DefaultDialer
-	}
+func NewResolver(dialer net.Dialer, lookups ...Lookup) Resolver {
 	r := &resolver{
 		resolvers: make(map[Lookup]bool),
 		dialer:    dialer,

--- a/xresolver/xresolver.go
+++ b/xresolver/xresolver.go
@@ -9,31 +9,6 @@ import (
 
 // Note to self: Dial is not being set for net.Resolver because that is the Dial to the DNS server.
 
-type Lookup interface {
-	// LookupIPAddr looks up host using the local resolver. It returns a slice of that host's IPv4 and IPv6 addresses.
-	LookupIPAddr(ctx context.Context, host string) ([]net.IPAddr, error)
-}
-
-type Dial interface {
-	// DialContext connects to the address on the named network using the provided context.
-	DialContext(ctx context.Context, network, addr string) (con net.Conn, err error)
-}
-
-type ConnCreation interface {
-	Dial(network, address string) (net.Conn, error)
-}
-
-// Resolver represents how to generate the address and how to create the connection
-type Resolver interface {
-	Dial
-
-	// Add adds the resolver to the methods of creating the IPv4 and IPv6 addresses
-	Add(r Lookup) error
-
-	// Remove removes the resolver to the methods of creating the IPv4 and IPv6 addresses
-	Remove(r Lookup) error
-}
-
 var DefaultDialer = &net.Dialer{}
 
 type resolver struct {
@@ -106,7 +81,7 @@ func (resolve *resolver) DialContext(ctx context.Context, network, addr string) 
 	// get records using custom resolvers
 	records := resolve.getRecords(ctx, host)
 
-	// generate Con or err from records
+	// generate Conn or err from records
 	con, err = resolve.createConnection(records, network, port)
 	if err == nil {
 		return

--- a/xresolver/xresolver_test.go
+++ b/xresolver/xresolver_test.go
@@ -21,7 +21,7 @@ func TestClient(t *testing.T) {
 
 	client := &http.Client{
 		Transport: &http.Transport{
-			DialContext: NewResolver(nil).DialContext,
+			DialContext: NewResolver(DefaultDialer).DialContext,
 		},
 	}
 
@@ -62,7 +62,7 @@ func TestClientWithResolver(t *testing.T) {
 
 	fakeLookUp := new(mockLookUp)
 	fakeLookUp.On("LookupRoutes", mock.Anything, customhost).Return([]Route{route}, nil)
-	r := NewResolver(nil, fakeLookUp)
+	r := NewResolver(DefaultDialer, fakeLookUp)
 
 	client := &http.Client{
 		Transport: &http.Transport{

--- a/xresolver/xresolver_test.go
+++ b/xresolver/xresolver_test.go
@@ -2,10 +2,10 @@ package xresolver
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"github.com/stretchr/testify/assert"
 	"io/ioutil"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -34,25 +34,25 @@ func TestClient(t *testing.T) {
 }
 
 type testCustomLookUp struct {
-	nameHost map[string]string
+	nameHost map[string]Route
 	usedMap  bool
 }
 
-func (c *testCustomLookUp) LookupIPAddr(ctx context.Context, host string) ([]net.IPAddr, error) {
-	item, found := c.nameHost[host]
-	if found {
-		records := make([]net.IPAddr, 1)
-		records[0] = net.IPAddr{IP: net.ParseIP(item), Zone: ""}
+func (c *testCustomLookUp) LookupRoutes(ctx context.Context, host string) ([]Route, error) {
+	if route, found := c.nameHost[host]; found {
+		records := make([]Route, 1)
+		records[0] = route
 		c.usedMap = true
 		return records, nil
 	}
-	return []net.IPAddr{}, nil
+	return []Route{}, errors.New("no routes found")
 }
 
 func TestClientWithResolver(t *testing.T) {
 	assert := assert.New(t)
 
 	customhost := "custom.host.com"
+	customport := "8080"
 	expectedBody := "Hello World\n"
 
 	serverA := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -60,14 +60,13 @@ func TestClientWithResolver(t *testing.T) {
 	}))
 	defer serverA.Close()
 
-	hostA, portA, err := net.SplitHostPort(serverA.Listener.Addr().String())
+	route, err := CreateRoute(serverA.URL)
 	assert.NoError(err)
 
-	r := NewResolver(nil)
 	customLookUp := &testCustomLookUp{
-		nameHost: map[string]string{customhost: hostA},
+		nameHost: map[string]Route{customhost: *route},
 	}
-	r.Add(customLookUp)
+	r := NewResolver(nil, customLookUp)
 
 	client := &http.Client{
 		Transport: &http.Transport{
@@ -76,25 +75,25 @@ func TestClientWithResolver(t *testing.T) {
 		},
 	}
 
-	req, err := http.NewRequest("GET", "http://"+customhost+":"+portA, nil)
+	req, err := http.NewRequest("GET", "http://"+customhost+":"+customport, nil)
 	assert.NoError(err)
 
 	res, err := client.Do(req)
-	assert.NoError(err)
+	if assert.NoError(err) {
+		body, err := ioutil.ReadAll(res.Body)
+		res.Body.Close()
+		assert.NoError(err)
 
-	body, err := ioutil.ReadAll(res.Body)
-	res.Body.Close()
-	assert.NoError(err)
-
-	assert.Equal(200, res.StatusCode)
-	assert.Equal(expectedBody, string(body))
-	assert.True(customLookUp.usedMap, "custom LookupIPAddr must be called")
+		assert.Equal(200, res.StatusCode)
+		assert.Equal(expectedBody, string(body))
+		assert.True(customLookUp.usedMap, "custom LookupIPAddr must be called")
+	}
 
 	// Remove CustomLook up
 	err = r.Remove(customLookUp)
 	assert.NoError(err)
 
-	req, err = http.NewRequest("GET", "http://"+customhost+":"+portA, nil)
+	req, err = http.NewRequest("GET", "http://"+customhost+":"+customport, nil)
 	assert.NoError(err)
 
 	res, err = client.Do(req)

--- a/xresolver/xresolver_test.go
+++ b/xresolver/xresolver_test.go
@@ -1,0 +1,102 @@
+package xresolver
+
+import (
+	"context"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestClient(t *testing.T) {
+	assert := assert.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "Hello, client")
+	}))
+	defer ts.Close()
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			DialContext: NewResolver(nil).DialContext,
+		},
+	}
+
+	req, err := http.NewRequest("GET", ts.URL, nil)
+	assert.NoError(err)
+
+	res, err := client.Do(req)
+	assert.NoError(err)
+	assert.Equal(200, res.StatusCode)
+}
+
+type testCustomLookUp struct {
+	nameHost map[string]string
+	usedMap  bool
+}
+
+func (c *testCustomLookUp) LookupIPAddr(ctx context.Context, host string) ([]net.IPAddr, error) {
+	item, found := c.nameHost[host]
+	if found {
+		records := make([]net.IPAddr, 1)
+		records[0] = net.IPAddr{IP: net.ParseIP(item), Zone: ""}
+		c.usedMap = true
+		return records, nil
+	}
+	return []net.IPAddr{}, nil
+}
+
+func TestClientWithResolver(t *testing.T) {
+	assert := assert.New(t)
+
+	customhost := "custom.host.com"
+	expectedBody := "Hello World\n"
+
+	serverA := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, expectedBody)
+	}))
+	defer serverA.Close()
+
+	hostA, portA, err := net.SplitHostPort(serverA.Listener.Addr().String())
+	assert.NoError(err)
+
+	r := NewResolver(nil)
+	customLookUp := &testCustomLookUp{
+		nameHost: map[string]string{customhost: hostA},
+	}
+	r.Add(customLookUp)
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			DialContext:       r.DialContext,
+			DisableKeepAlives: true,
+		},
+	}
+
+	req, err := http.NewRequest("GET", "http://"+customhost+":"+portA, nil)
+	assert.NoError(err)
+
+	res, err := client.Do(req)
+	assert.NoError(err)
+
+	body, err := ioutil.ReadAll(res.Body)
+	res.Body.Close()
+	assert.NoError(err)
+
+	assert.Equal(200, res.StatusCode)
+	assert.Equal(expectedBody, string(body))
+	assert.True(customLookUp.usedMap, "custom LookupIPAddr must be called")
+
+	// Remove CustomLook up
+	err = r.Remove(customLookUp)
+	assert.NoError(err)
+
+	req, err = http.NewRequest("GET", "http://"+customhost+":"+portA, nil)
+	assert.NoError(err)
+
+	res, err = client.Do(req)
+	assert.Error(err)
+}


### PR DESCRIPTION
When this package is used, the transport layer will dial  a custom route instead of the original route.

# Usage:
For example, the following will dial `customA.host.com:8080` instead of `custom.host.com:9090`. 

```go
	watcher := NewConsulWatcher(&Options{
		Watch: map[string]string{"custom.host.com": "myService"},
	})

	// note: MonitorEvent is the Listener interface in the monitor package
	watcher.MonitorEvent(monitor.Event{
		Key:       service + "[tag tagA]" + "{passingOnly=true}",
		Instances: []string{"http://customA.host.com:8080"},
	})

	client := &http.Client{
		Transport: &http.Transport{
			DialContext:       xresolver.NewResolver(nil, watcher).DialContext,
			// note: DisableKeepAlives is required so when we do the request again we don't reuse the same connection.
			DisableKeepAlives: true,
		},
	}

	req, err := http.NewRequest("GET", "http://custom.host.com:9090", nil)
	assert.NoError(err)

	res, err := client.Do(req)
```

# What is added in this package:
- create `DialContext` logic for the transport layer.
- added a RoundRobin balancer
 - created a consul watcher that uses the RoundRobin balancer and updates the routes via consul.