### PR TITLE
Feature/semaphore

### DIFF
--- a/semaphore/doc.go
+++ b/semaphore/doc.go
@@ -1,0 +1,4 @@
+/*
+Package semaphore provides a simple channel-based semaphore that optionally honors context semantics.
+*/
+package semaphore

--- a/semaphore/instrument.go
+++ b/semaphore/instrument.go
@@ -35,7 +35,8 @@ func WithFailures(a xmetrics.Adder) InstrumentOption {
 	}
 }
 
-// Instrument decorates an existing semaphore with a set of options.
+// Instrument decorates an existing semaphore with instrumentation.  The available options
+// allow tracking the number of resources currently acquired and the total count of failures over time.
 func Instrument(s Interface, o ...InstrumentOption) Interface {
 	if s == nil {
 		panic("A delegate semaphore is required")
@@ -54,6 +55,7 @@ func Instrument(s Interface, o ...InstrumentOption) Interface {
 	return is
 }
 
+// instrumentedSemaphore is the internal decorator around Interface that applies appropriate metrics.
 type instrumentedSemaphore struct {
 	Interface
 	resources xmetrics.Adder

--- a/semaphore/instrument.go
+++ b/semaphore/instrument.go
@@ -1,0 +1,90 @@
+package semaphore
+
+import (
+	"context"
+	"time"
+
+	"github.com/Comcast/webpa-common/xmetrics"
+	"github.com/go-kit/kit/metrics/discard"
+)
+
+// InstrumentOption represents a configurable option for instrumenting a semaphore
+type InstrumentOption func(*instrumentedSemaphore)
+
+// WithResources establishes a metric that tracks the resource count of the semaphore.
+// If a nil counter is supplied, resource counts are discarded.
+func WithResources(a xmetrics.Adder) InstrumentOption {
+	return func(i *instrumentedSemaphore) {
+		if a != nil {
+			i.resources = a
+		} else {
+			i.resources = discard.NewCounter()
+		}
+	}
+}
+
+// WithErrors establishes a metric that tracks how many errors, or failed resource acquisitions,
+// happen when attempting to acquire resources.  If a nil counter is supplied, error counts
+// are discarded.
+func WithErrors(a xmetrics.Adder) InstrumentOption {
+	return func(i *instrumentedSemaphore) {
+		if a != nil {
+			i.errors = a
+		} else {
+			i.errors = discard.NewCounter()
+		}
+	}
+}
+
+// Instrument decorates an existing semaphore with a set of options.
+func Instrument(s Interface, o ...InstrumentOption) Interface {
+	is := &instrumentedSemaphore{
+		Interface: s,
+		resources: discard.NewCounter(),
+		errors:    discard.NewCounter(),
+	}
+
+	for _, f := range o {
+		f(is)
+	}
+
+	return is
+}
+
+type instrumentedSemaphore struct {
+	Interface
+	resources xmetrics.Adder
+	errors    xmetrics.Adder
+}
+
+func (is *instrumentedSemaphore) Acquire() {
+	is.Interface.Acquire()
+	is.resources.Add(1.0)
+}
+
+func (is *instrumentedSemaphore) AcquireWait(t <-chan time.Time) (err error) {
+	err = is.Interface.AcquireWait(t)
+	if err != nil {
+		is.errors.Add(1.0)
+	} else {
+		is.resources.Add(1.0)
+	}
+
+	return
+}
+
+func (is *instrumentedSemaphore) AcquireCtx(ctx context.Context) (err error) {
+	err = is.Interface.AcquireCtx(ctx)
+	if err != nil {
+		is.errors.Add(1.0)
+	} else {
+		is.resources.Add(1.0)
+	}
+
+	return
+}
+
+func (is *instrumentedSemaphore) Release() {
+	is.Interface.Release()
+	is.resources.Add(-1.0)
+}

--- a/semaphore/instrument_test.go
+++ b/semaphore/instrument_test.go
@@ -194,10 +194,12 @@ func testInstrumentedSemaphoreAcquireCtxSuccess(t *testing.T) {
 		failures  = generic.NewCounter("test")
 		s         = Instrument(Mutex(), WithResources(resources), WithFailures(failures))
 
-		ready  = make(chan struct{})
-		result = make(chan error)
-		ctx, _ = context.WithCancel(context.Background())
+		ready       = make(chan struct{})
+		result      = make(chan error)
+		ctx, cancel = context.WithCancel(context.Background())
 	)
+
+	defer cancel()
 
 	go func() {
 		s.Acquire()
@@ -239,6 +241,8 @@ func testInstrumentedSemaphoreAcquireCtxCancel(t *testing.T) {
 		result      = make(chan error)
 		ctx, cancel = context.WithCancel(context.Background())
 	)
+
+	defer cancel()
 
 	go func() {
 		s.Acquire()

--- a/semaphore/instrument_test.go
+++ b/semaphore/instrument_test.go
@@ -1,0 +1,285 @@
+package semaphore
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-kit/kit/metrics/generic"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithResources(t *testing.T) {
+	var (
+		assert = assert.New(t)
+		is     = new(instrumentedSemaphore)
+
+		custom = generic.NewCounter("test")
+	)
+
+	WithResources(nil)(is)
+	assert.NotNil(is.resources)
+
+	WithResources(custom)(is)
+	assert.Equal(custom, is.resources)
+}
+
+func TestWithFailures(t *testing.T) {
+	var (
+		assert = assert.New(t)
+		is     = new(instrumentedSemaphore)
+
+		custom = generic.NewCounter("test")
+	)
+
+	WithFailures(nil)(is)
+	assert.NotNil(is.failures)
+
+	WithFailures(custom)(is)
+	assert.Equal(custom, is.failures)
+}
+
+func testInstrumentNilSemaphore(t *testing.T) {
+	assert.Panics(t,
+		func() {
+			Instrument(nil)
+		},
+	)
+}
+
+func TestInstrument(t *testing.T) {
+	t.Run("NilSemaphore", testInstrumentNilSemaphore)
+}
+
+func testInstrumentedSemaphoreAcquire(t *testing.T) {
+	var (
+		assert    = assert.New(t)
+		resources = generic.NewCounter("test")
+		failures  = generic.NewCounter("test")
+		s         = Instrument(Mutex(), WithResources(resources), WithFailures(failures))
+
+		ready = make(chan struct{})
+	)
+
+	go func() {
+		defer close(ready)
+		s.Acquire()
+	}()
+
+	select {
+	case <-ready:
+		assert.Equal(float64(1.0), resources.Value())
+		assert.Zero(failures.Value())
+
+		s.Release()
+		assert.Zero(resources.Value())
+		assert.Zero(failures.Value())
+	case <-time.After(time.Second):
+		assert.FailNow("Acquire blocked unexpectedly")
+	}
+}
+
+func testInstrumentedSemaphoreTryAcquire(t *testing.T) {
+	var (
+		assert    = assert.New(t)
+		require   = require.New(t)
+		resources = generic.NewCounter("test")
+		failures  = generic.NewCounter("test")
+		s         = Instrument(Mutex(), WithResources(resources), WithFailures(failures))
+	)
+
+	assert.Zero(resources.Value())
+	assert.Zero(failures.Value())
+
+	require.True(s.TryAcquire())
+	assert.Equal(float64(1.0), resources.Value())
+	assert.Zero(failures.Value())
+
+	require.False(s.TryAcquire())
+	assert.Equal(float64(1.0), resources.Value())
+	assert.Equal(float64(1.0), failures.Value())
+
+	s.Release()
+	assert.Zero(resources.Value())
+	assert.Equal(float64(1.0), failures.Value())
+}
+
+func testInstrumentedSemaphoreAcquireWaitSuccess(t *testing.T) {
+	var (
+		assert    = assert.New(t)
+		resources = generic.NewCounter("test")
+		failures  = generic.NewCounter("test")
+		s         = Instrument(Mutex(), WithResources(resources), WithFailures(failures))
+
+		ready  = make(chan struct{})
+		result = make(chan error)
+		timer  = make(chan time.Time)
+	)
+
+	go func() {
+		s.Acquire()
+		close(ready)
+		result <- s.AcquireWait(timer)
+	}()
+
+	select {
+	case <-ready:
+		assert.Equal(float64(1.0), resources.Value())
+		assert.Zero(failures.Value())
+		s.Release()
+	case <-time.After(time.Second):
+		assert.FailNow("Failed to spawn AcquireWait goroutine")
+	}
+
+	select {
+	case err := <-result:
+		assert.NoError(err)
+		assert.Equal(float64(1.0), resources.Value())
+		assert.Zero(failures.Value())
+
+		s.Release()
+		assert.Zero(resources.Value())
+		assert.Zero(failures.Value())
+	case <-time.After(time.Second):
+		assert.FailNow("AcquireWait blocked unexpectedly")
+	}
+}
+
+func testInstrumentedSemaphoreAcquireWaitTimeout(t *testing.T) {
+	var (
+		assert    = assert.New(t)
+		resources = generic.NewCounter("test")
+		failures  = generic.NewCounter("test")
+		s         = Instrument(Mutex(), WithResources(resources), WithFailures(failures))
+
+		ready  = make(chan struct{})
+		result = make(chan error)
+		timer  = make(chan time.Time)
+	)
+
+	go func() {
+		s.Acquire()
+		close(ready)
+		result <- s.AcquireWait(timer)
+	}()
+
+	select {
+	case <-ready:
+		assert.Equal(float64(1.0), resources.Value())
+		assert.Zero(failures.Value())
+		timer <- time.Time{}
+	case <-time.After(time.Second):
+		assert.FailNow("Failed to spawn AcquireWait goroutine")
+	}
+
+	select {
+	case err := <-result:
+		assert.Equal(ErrTimeout, err)
+		assert.Equal(float64(1.0), resources.Value())
+		assert.Equal(float64(1.0), failures.Value())
+
+		s.Release()
+		assert.Zero(resources.Value())
+		assert.Equal(float64(1.0), failures.Value())
+	case <-time.After(time.Second):
+		assert.FailNow("AcquireWait blocked unexpectedly")
+	}
+}
+
+func testInstrumentedSemaphoreAcquireCtxSuccess(t *testing.T) {
+	var (
+		assert    = assert.New(t)
+		resources = generic.NewCounter("test")
+		failures  = generic.NewCounter("test")
+		s         = Instrument(Mutex(), WithResources(resources), WithFailures(failures))
+
+		ready  = make(chan struct{})
+		result = make(chan error)
+		ctx, _ = context.WithCancel(context.Background())
+	)
+
+	go func() {
+		s.Acquire()
+		close(ready)
+		result <- s.AcquireCtx(ctx)
+	}()
+
+	select {
+	case <-ready:
+		assert.Equal(float64(1.0), resources.Value())
+		assert.Zero(failures.Value())
+		s.Release()
+	case <-time.After(time.Second):
+		assert.FailNow("Failed to spawn AcquireCtx goroutine")
+	}
+
+	select {
+	case err := <-result:
+		assert.NoError(err)
+		assert.Equal(float64(1.0), resources.Value())
+		assert.Zero(failures.Value())
+
+		s.Release()
+		assert.Zero(resources.Value())
+		assert.Zero(failures.Value())
+	case <-time.After(time.Second):
+		assert.FailNow("AcquireCtx blocked unexpectedly")
+	}
+}
+
+func testInstrumentedSemaphoreAcquireCtxCancel(t *testing.T) {
+	var (
+		assert    = assert.New(t)
+		resources = generic.NewCounter("test")
+		failures  = generic.NewCounter("test")
+		s         = Instrument(Mutex(), WithResources(resources), WithFailures(failures))
+
+		ready       = make(chan struct{})
+		result      = make(chan error)
+		ctx, cancel = context.WithCancel(context.Background())
+	)
+
+	go func() {
+		s.Acquire()
+		close(ready)
+		result <- s.AcquireCtx(ctx)
+	}()
+
+	select {
+	case <-ready:
+		assert.Equal(float64(1.0), resources.Value())
+		assert.Zero(failures.Value())
+		cancel()
+	case <-time.After(time.Second):
+		assert.FailNow("Failed to spawn AcquireCtx goroutine")
+	}
+
+	select {
+	case err := <-result:
+		assert.Equal(ctx.Err(), err)
+		assert.Equal(float64(1.0), resources.Value())
+		assert.Equal(float64(1.0), failures.Value())
+
+		s.Release()
+		assert.Zero(resources.Value())
+		assert.Equal(float64(1.0), failures.Value())
+	case <-time.After(time.Second):
+		assert.FailNow("AcquireCtx blocked unexpectedly")
+	}
+}
+
+func TestInstrumentedSemaphore(t *testing.T) {
+	t.Run("Acquire", testInstrumentedSemaphoreAcquire)
+	t.Run("TryAcquire", testInstrumentedSemaphoreTryAcquire)
+
+	t.Run("AcquireWait", func(t *testing.T) {
+		t.Run("Success", testInstrumentedSemaphoreAcquireWaitSuccess)
+		t.Run("Timeout", testInstrumentedSemaphoreAcquireWaitTimeout)
+	})
+
+	t.Run("AcquireCtx", func(t *testing.T) {
+		t.Run("Success", testInstrumentedSemaphoreAcquireCtxSuccess)
+		t.Run("Cancel", testInstrumentedSemaphoreAcquireCtxCancel)
+	})
+}

--- a/semaphore/semaphore.go
+++ b/semaphore/semaphore.go
@@ -1,0 +1,82 @@
+package semaphore
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+var (
+	// ErrTimeout is returned when a timeout occurs while waiting to acquire a semaphore resource.
+	// This error does not apply when using a context.  ctx.Err() is returned in that case.
+	ErrTimeout = errors.New("The semaphore could not be acquired within the timeout")
+)
+
+// Interface represents a semaphore, either binary or counting.
+type Interface interface {
+	// Acquire acquires a resource.  This method blocks forever until a resource can be acquired.
+	Acquire()
+
+	// AcquireWait attempts to acquire a resource before the given time channel becomes signaled.
+	// If the resource was acquired, this method returns nil.  If the time channel gets signaled
+	// before a resource is available, ErrTimeout is returned.
+	AcquireWait(<-chan time.Time) error
+
+	// AcquireCtx attempts to acquire a resource before the given context is canceled.  If the resource
+	// was acquired, this method returns nil.  Otherwise, this method returns ctx.Err().
+	AcquireCtx(context.Context) error
+
+	// Release relinquishes control of a resource.  If called before a corresponding acquire method,
+	// this method will likely result in a deadlock.  This method must be invoked after a successful
+	// acquire in order to allow other goroutines to use the resource(s).
+	Release()
+}
+
+// New constructs a semaphore with the given count.  A nonpositive count will result in a panic.
+// A count of 1 is essentially a mutex, albeit with the ability to timeout or cancel the acquisition
+// of the lock.
+func New(count int) Interface {
+	if count < 1 {
+		panic("The count must be positive")
+	}
+
+	return &semaphore{
+		c: make(chan struct{}, count),
+	}
+}
+
+// Mutex is just syntactic sugar for New(1).
+func Mutex() Interface {
+	return New(1)
+}
+
+// semaphore is the internal Interface implementation
+type semaphore struct {
+	c chan struct{}
+}
+
+func (s *semaphore) Acquire() {
+	s.c <- struct{}{}
+}
+
+func (s *semaphore) AcquireWait(t <-chan time.Time) error {
+	select {
+	case s.c <- struct{}{}:
+		return nil
+	case <-t:
+		return ErrTimeout
+	}
+}
+
+func (s *semaphore) AcquireCtx(ctx context.Context) error {
+	select {
+	case s.c <- struct{}{}:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (s *semaphore) Release() {
+	<-s.c
+}

--- a/semaphore/semaphore_test.go
+++ b/semaphore/semaphore_test.go
@@ -4,12 +4,43 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func ExampleMutex() {
+	const routineCount = 5
+
+	var (
+		s     = Mutex()
+		wg    = new(sync.WaitGroup)
+		value int
+	)
+
+	wg.Add(routineCount)
+	for i := 0; i < routineCount; i++ {
+		go func(i int) {
+			defer wg.Done()
+			defer s.Release()
+			s.Acquire()
+			value++
+			fmt.Println(i)
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Unordered output:
+	// 0
+	// 1
+	// 2
+	// 3
+	// 4
+}
 
 func testNewInvalidCount(t *testing.T) {
 	for _, c := range []int{0, -1} {

--- a/semaphore/semaphore_test.go
+++ b/semaphore/semaphore_test.go
@@ -23,23 +23,23 @@ func ExampleMutex() {
 
 	wg.Add(routineCount)
 	for i := 0; i < routineCount; i++ {
-		go func(i int) {
+		go func() {
 			defer wg.Done()
 			defer s.Release()
 			s.Acquire()
 			value++
-			fmt.Println(i)
-		}(i)
+			fmt.Println(value)
+		}()
 	}
 
 	wg.Wait()
 
 	// Unordered output:
-	// 0
 	// 1
 	// 2
 	// 3
 	// 4
+	// 5
 }
 
 func testNewInvalidCount(t *testing.T) {
@@ -96,7 +96,7 @@ func testAcquire(t *testing.T, s Interface, totalCount int) {
 		case <-done:
 			// passing
 		case <-time.After(time.Second):
-			assert.Fail("Acquire blocked unexpectedly")
+			assert.FailNow("Acquire blocked unexpectedly")
 		}
 	}
 
@@ -120,14 +120,14 @@ func testAcquire(t *testing.T, s Interface, totalCount int) {
 		require.False(s.TryAcquire())
 		s.Release()
 	case <-time.After(time.Second):
-		require.Fail("Unable to spawn acquire goroutine")
+		require.FailNow("Unable to spawn acquire goroutine")
 	}
 
 	select {
 	case <-acquired:
 		require.False(s.TryAcquire())
 	case <-time.After(time.Second):
-		require.Fail("Acquire blocked unexpectedly")
+		require.FailNow("Acquire blocked unexpectedly")
 	}
 
 	s.Release()
@@ -152,7 +152,7 @@ func testAcquireWait(t *testing.T, s Interface, totalCount int) {
 		case err := <-result:
 			assert.NoError(err)
 		case <-time.After(time.Second):
-			assert.Fail("Acquire blocked unexpectedly")
+			assert.FailNow("Acquire blocked unexpectedly")
 		}
 	}
 
@@ -173,14 +173,14 @@ func testAcquireWait(t *testing.T, s Interface, totalCount int) {
 	case <-ready:
 		timer <- time.Time{}
 	case <-time.After(time.Second):
-		require.Fail("Unable to spawn acquire goroutine")
+		require.FailNow("Unable to spawn acquire goroutine")
 	}
 
 	select {
 	case err := <-result:
 		assert.Equal(ErrTimeout, err)
 	case <-time.After(time.Second):
-		require.Fail("AcquireWait blocked unexpectedly")
+		require.FailNow("AcquireWait blocked unexpectedly")
 	}
 }
 
@@ -202,7 +202,7 @@ func testAcquireCtx(t *testing.T, s Interface, totalCount int) {
 		case err := <-result:
 			assert.NoError(err)
 		case <-time.After(time.Second):
-			assert.Fail("Acquire blocked unexpectedly")
+			assert.FailNow("Acquire blocked unexpectedly")
 		}
 	}
 
@@ -223,14 +223,14 @@ func testAcquireCtx(t *testing.T, s Interface, totalCount int) {
 	case <-ready:
 		cancel()
 	case <-time.After(time.Second):
-		require.Fail("Unable to spawn acquire goroutine")
+		require.FailNow("Unable to spawn acquire goroutine")
 	}
 
 	select {
 	case err := <-result:
 		assert.Equal(ctx.Err(), err)
 	case <-time.After(time.Second):
-		require.Fail("AcquireWait blocked unexpectedly")
+		require.FailNow("AcquireWait blocked unexpectedly")
 	}
 }
 

--- a/semaphore/semaphore_test.go
+++ b/semaphore/semaphore_test.go
@@ -42,6 +42,20 @@ func ExampleMutex() {
 	// 5
 }
 
+func ExampleAcquireWait() {
+	var (
+		s     = Mutex()
+		timer = time.NewTimer(100 * time.Millisecond)
+	)
+
+	defer timer.Stop()
+	s.Acquire() // force AcquireWait to wait
+	fmt.Println(s.AcquireWait(timer.C))
+
+	// Output:
+	// The semaphore could not be acquired within the timeout
+}
+
 func testNewInvalidCount(t *testing.T) {
 	for _, c := range []int{0, -1} {
 		t.Run(strconv.Itoa(c), func(t *testing.T) {

--- a/semaphore/semaphore_test.go
+++ b/semaphore/semaphore_test.go
@@ -42,20 +42,6 @@ func ExampleMutex() {
 	// 5
 }
 
-func ExampleAcquireWait() {
-	var (
-		s     = Mutex()
-		timer = time.NewTimer(100 * time.Millisecond)
-	)
-
-	defer timer.Stop()
-	s.Acquire() // force AcquireWait to wait
-	fmt.Println(s.AcquireWait(timer.C))
-
-	// Output:
-	// The semaphore could not be acquired within the timeout
-}
-
 func testNewInvalidCount(t *testing.T) {
 	for _, c := range []int{0, -1} {
 		t.Run(strconv.Itoa(c), func(t *testing.T) {
@@ -204,6 +190,8 @@ func testAcquireCtx(t *testing.T, s Interface, totalCount int) {
 		require     = require.New(t)
 		ctx, cancel = context.WithCancel(context.Background())
 	)
+
+	defer cancel()
 
 	// acquire all the things!
 	for i := 0; i < totalCount; i++ {

--- a/semaphore/semaphore_test.go
+++ b/semaphore/semaphore_test.go
@@ -1,0 +1,244 @@
+package semaphore
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testNewInvalidCount(t *testing.T) {
+	for _, c := range []int{0, -1} {
+		t.Run(strconv.Itoa(c), func(t *testing.T) {
+			assert.Panics(t, func() {
+				New(c)
+			})
+		})
+	}
+}
+
+func testNewValidCount(t *testing.T) {
+	for _, c := range []int{1, 2, 5} {
+		t.Run(strconv.Itoa(c), func(t *testing.T) {
+			s := New(c)
+			assert.NotNil(t, s)
+		})
+	}
+}
+
+func TestNew(t *testing.T) {
+	t.Run("InvalidCount", testNewInvalidCount)
+	t.Run("ValidCount", testNewValidCount)
+}
+
+func testTryAcquire(t *testing.T, s Interface, totalCount int) {
+	assert := assert.New(t)
+	for i := 0; i < totalCount; i++ {
+		assert.True(s.TryAcquire())
+	}
+
+	assert.False(s.TryAcquire())
+	s.Release()
+	assert.True(s.TryAcquire())
+	assert.False(s.TryAcquire())
+}
+
+func testAcquire(t *testing.T, s Interface, totalCount int) {
+	var (
+		assert  = assert.New(t)
+		require = require.New(t)
+	)
+
+	// acquire all the things!
+	for i := 0; i < totalCount; i++ {
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			s.Acquire()
+		}()
+
+		select {
+		case <-done:
+			// passing
+		case <-time.After(time.Second):
+			assert.Fail("Acquire blocked unexpectedly")
+		}
+	}
+
+	// post condition: no point continuing if this fails
+	require.False(s.TryAcquire())
+
+	var (
+		ready    = make(chan struct{})
+		acquired = make(chan struct{})
+	)
+
+	go func() {
+		defer close(acquired)
+		close(ready)
+		s.Acquire() // this should now block
+	}()
+
+	select {
+	case <-ready:
+		// passing
+		require.False(s.TryAcquire())
+		s.Release()
+	case <-time.After(time.Second):
+		require.Fail("Unable to spawn acquire goroutine")
+	}
+
+	select {
+	case <-acquired:
+		require.False(s.TryAcquire())
+	case <-time.After(time.Second):
+		require.Fail("Acquire blocked unexpectedly")
+	}
+
+	s.Release()
+	assert.True(s.TryAcquire())
+}
+
+func testAcquireWait(t *testing.T, s Interface, totalCount int) {
+	var (
+		assert  = assert.New(t)
+		require = require.New(t)
+		timer   = make(chan time.Time)
+	)
+
+	// acquire all the things!
+	for i := 0; i < totalCount; i++ {
+		result := make(chan error)
+		go func() {
+			result <- s.AcquireWait(timer)
+		}()
+
+		select {
+		case err := <-result:
+			assert.NoError(err)
+		case <-time.After(time.Second):
+			assert.Fail("Acquire blocked unexpectedly")
+		}
+	}
+
+	// post condition: no point continuing if this fails
+	require.False(s.TryAcquire())
+
+	var (
+		ready  = make(chan struct{})
+		result = make(chan error)
+	)
+
+	go func() {
+		close(ready)
+		result <- s.AcquireWait(timer)
+	}()
+
+	select {
+	case <-ready:
+		timer <- time.Time{}
+	case <-time.After(time.Second):
+		require.Fail("Unable to spawn acquire goroutine")
+	}
+
+	select {
+	case err := <-result:
+		assert.Equal(ErrTimeout, err)
+	case <-time.After(time.Second):
+		require.Fail("AcquireWait blocked unexpectedly")
+	}
+}
+
+func testAcquireCtx(t *testing.T, s Interface, totalCount int) {
+	var (
+		assert      = assert.New(t)
+		require     = require.New(t)
+		ctx, cancel = context.WithCancel(context.Background())
+	)
+
+	// acquire all the things!
+	for i := 0; i < totalCount; i++ {
+		result := make(chan error)
+		go func() {
+			result <- s.AcquireCtx(ctx)
+		}()
+
+		select {
+		case err := <-result:
+			assert.NoError(err)
+		case <-time.After(time.Second):
+			assert.Fail("Acquire blocked unexpectedly")
+		}
+	}
+
+	// post condition: no point continuing if this fails
+	require.False(s.TryAcquire())
+
+	var (
+		ready  = make(chan struct{})
+		result = make(chan error)
+	)
+
+	go func() {
+		close(ready)
+		result <- s.AcquireCtx(ctx)
+	}()
+
+	select {
+	case <-ready:
+		cancel()
+	case <-time.After(time.Second):
+		require.Fail("Unable to spawn acquire goroutine")
+	}
+
+	select {
+	case err := <-result:
+		assert.Equal(ctx.Err(), err)
+	case <-time.After(time.Second):
+		require.Fail("AcquireWait blocked unexpectedly")
+	}
+}
+
+func TestSemaphore(t *testing.T) {
+	for _, c := range []int{1, 2, 5} {
+		t.Run(fmt.Sprintf("count=%d", c), func(t *testing.T) {
+			t.Run("TryAcquire", func(t *testing.T) {
+				testTryAcquire(t, New(c), c)
+			})
+
+			t.Run("Acquire", func(t *testing.T) {
+				testAcquire(t, New(c), c)
+			})
+
+			t.Run("AcquireWait", func(t *testing.T) {
+				testAcquireWait(t, New(c), c)
+			})
+
+			t.Run("AcquireCtx", func(t *testing.T) {
+				testAcquireCtx(t, New(c), c)
+			})
+		})
+	}
+}
+
+func TestMutex(t *testing.T) {
+	t.Run("TryAcquire", func(t *testing.T) {
+		testTryAcquire(t, Mutex(), 1)
+	})
+
+	t.Run("Acquire", func(t *testing.T) {
+		testAcquire(t, Mutex(), 1)
+	})
+
+	t.Run("AcquireWait", func(t *testing.T) {
+		testAcquireWait(t, Mutex(), 1)
+	})
+
+	t.Run("AcquireCtx", func(t *testing.T) {
+		testAcquireCtx(t, Mutex(), 1)
+	})
+}

--- a/semaphore/semaphore_test.go
+++ b/semaphore/semaphore_test.go
@@ -42,6 +42,21 @@ func ExampleMutex() {
 	// 5
 }
 
+func ExampleInterface_AcquireWait() {
+	var (
+		s     = Mutex()
+		timer = time.NewTimer(100 * time.Millisecond)
+	)
+
+	defer timer.Stop()
+	s.Acquire() // force AcquireWait to block
+	err := s.AcquireWait(timer.C)
+	fmt.Println(err != nil)
+
+	// Output:
+	// true
+}
+
 func testNewInvalidCount(t *testing.T) {
 	for _, c := range []int{0, -1} {
 		t.Run(strconv.Itoa(c), func(t *testing.T) {


### PR DESCRIPTION
Here's a simple, reusable semaphore that's custom to our needs.  It provides both a binary (mutex) and a counting semaphore, decided at construction time.

I'm not sure what everyone's familiarity and comfort with `golang` idioms and highly concurrent programming are.  So, this PR is for educational purposes.

Additionally, this PR illustrates what in my opinion is the appropriate approach for testing.  Rather than being concerned with code coverage, the test code is more interested in branching and concurrency.
