### PR TITLE
Adds device metrics for convey headers

### DIFF
--- a/convey/conveymetric/metric.go
+++ b/convey/conveymetric/metric.go
@@ -1,0 +1,67 @@
+package conveymetric
+
+import (
+	"fmt"
+	"github.com/Comcast/webpa-common/convey"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const UnknownLabel = "unknown"
+
+type MetricClosure func()
+
+type CMetric interface {
+	Update(data convey.C) (MetricClosure, error)
+	GetMetrics() []prometheus.Collector
+}
+
+func NewConveyMetric(tag string, name string) CMetric {
+	return &cMetric{
+		Tag:     tag,
+		Name:    name,
+		metrics: make(map[string]prometheus.Gauge),
+	}
+}
+
+type cMetric struct {
+	Tag     string
+	Name    string
+	metrics map[string]prometheus.Gauge
+}
+
+func (m *cMetric) Update(data convey.C) (MetricClosure, error) {
+	var gague prometheus.Gauge
+
+	key := UnknownLabel
+
+	if item, ok := data[m.Tag].(string); ok {
+		key = item
+	}
+
+	if val, found := m.metrics[key]; found {
+		gague = val
+	} else {
+		m.metrics[key] = prometheus.NewGauge(prometheus.GaugeOpts{
+			Name:      fmt.Sprintf("%s_%s_%s", m.Name, m.Tag, key),
+			Namespace: "convey",
+			Subsystem: "convey",
+			Help:      fmt.Sprintf("Convey Metrics %s for %s and value %s", m.Name, m.Tag, key),
+		})
+		gague = m.metrics[key]
+	}
+
+	gague.Inc()
+	return func() { gague.Dec() }, nil
+}
+
+func (m *cMetric) GetMetrics() []prometheus.Collector {
+	metrics := make([]prometheus.Collector, len(m.metrics))
+
+	index := 0
+	for _, v := range m.metrics {
+		metrics[index] = v
+		index++
+	}
+
+	return metrics
+}

--- a/convey/conveymetric/metric.go
+++ b/convey/conveymetric/metric.go
@@ -8,23 +8,23 @@ import (
 // UnknownLabel is a constant for when key/tag can not be found in the C JSON
 const UnknownLabel = "unknown"
 
-// MetricClosure will be returned after update of struct, this should be used to update the struct, aka decrement the count
-type MetricClosure func()
+// Closure will be returned after Update(), this should be used to update the struct, aka decrement the count
+type Closure func()
 
-// CMetric provides
-type CMetric interface {
+// Interface provides a way of updating an internal resource
+type Interface interface {
 	// Update takes the convey JSON to update internal struct, and return a closure to update the struct again, or an
 	// error
 	//
-	// Note: MetricClosure should only be called once.
-	Update(data convey.C) (MetricClosure, error)
+	// Note: Closure should only be called once.
+	Update(data convey.C) (Closure, error)
 }
 
-// NewConveyMetric produces a CMetric where gauge is the internal structure to update, tag is the key in the C JSON
+// NewConveyMetric produces an Interface where gauge is the internal structure to update, tag is the key in the C JSON
 // to update the gauge, and label is the `key` for the gauge cardinality.
 //
 // Note: The Gauge must have the label as one of the constant labels, (aka. the name of the gauge)
-func NewConveyMetric(gauge metrics.Gauge, tag string, label string) CMetric {
+func NewConveyMetric(gauge metrics.Gauge, tag string, label string) Interface {
 	return &cMetric{
 		tag:   tag,
 		label: label,
@@ -32,14 +32,14 @@ func NewConveyMetric(gauge metrics.Gauge, tag string, label string) CMetric {
 	}
 }
 
-// cMetric is the internal CMetric implementation
+// cMetric is the internal Interface implementation
 type cMetric struct {
 	tag   string
 	label string
 	gauge metrics.Gauge
 }
 
-func (m *cMetric) Update(data convey.C) (MetricClosure, error) {
+func (m *cMetric) Update(data convey.C) (Closure, error) {
 	key := UnknownLabel
 	if item, ok := data[m.tag].(string); ok {
 		key = item

--- a/convey/conveymetric/metric.go
+++ b/convey/conveymetric/metric.go
@@ -18,7 +18,7 @@ type CMetric interface {
 }
 
 var (
-	validKeyRegex   = regexp.MustCompile(`^[a-zA-Z_:]*$`)
+	validKeyRegex   = regexp.MustCompile(`^[a-zA-Z_:]+$`)
 	replaceRegex    = regexp.MustCompile(`[\W]+`)
 	underscoreRegex = regexp.MustCompile(`_+`)
 )

--- a/convey/conveymetric/metric.go
+++ b/convey/conveymetric/metric.go
@@ -21,13 +21,13 @@ type CMetric interface {
 }
 
 // NewConveyMetric produces a CMetric where gauge is the internal structure to update, tag is the key in the C JSON
-// to update the gauge, and metricName is the `key` for the gauge cardinality.
+// to update the gauge, and label is the `key` for the gauge cardinality.
 //
-// Note: The Gauge must have the metricName as one of the constant labels
-func NewConveyMetric(gauge metrics.Gauge, tag string, metricName string) CMetric {
+// Note: The Gauge must have the label as one of the constant labels, (aka. the name of the gauge)
+func NewConveyMetric(gauge metrics.Gauge, tag string, label string) CMetric {
 	return &cMetric{
 		tag:   tag,
-		metricName:  metricName,
+		label: label,
 		gauge: gauge,
 	}
 }
@@ -35,7 +35,7 @@ func NewConveyMetric(gauge metrics.Gauge, tag string, metricName string) CMetric
 // cMetric is the internal CMetric implementation
 type cMetric struct {
 	tag   string
-	metricName  string
+	label string
 	gauge metrics.Gauge
 }
 
@@ -45,6 +45,6 @@ func (m *cMetric) Update(data convey.C) (MetricClosure, error) {
 		key = item
 	}
 
-	m.gauge.With(m.metricName, key).Add(1.0)
-	return func() { m.gauge.With(m.metricName, key).Add(-1.0) }, nil
+	m.gauge.With(m.label, key).Add(1.0)
+	return func() { m.gauge.With(m.label, key).Add(-1.0) }, nil
 }

--- a/convey/conveymetric/metric.go
+++ b/convey/conveymetric/metric.go
@@ -43,7 +43,7 @@ func (m *cMetric) Update(data convey.C) (MetricClosure, error) {
 	if val, found := m.metrics[key]; found {
 		gague = val
 	} else {
-		m.metrics[key] = m.provider.NewGauge(fmt.Sprintf("%s_%s_%s", m.name, m.tag, key))
+		m.metrics[key] = m.provider.NewGauge(fmt.Sprintf("%s_%s", m.name, key))
 		gague = m.metrics[key]
 	}
 

--- a/convey/conveymetric/metric.go
+++ b/convey/conveymetric/metric.go
@@ -3,24 +3,27 @@ package conveymetric
 import (
 	"github.com/Comcast/webpa-common/convey"
 	"github.com/go-kit/kit/metrics"
-	"regexp"
-	"strings"
 )
 
+// UnknownLabel is a constant for when key/tag can not be found in the C JSON
 const UnknownLabel = "unknown"
 
+// MetricClosure will be returned after update of struct, this should be used to update the struct, aka decrement the count
 type MetricClosure func()
 
+// CMetric provides
 type CMetric interface {
+	// Update takes the convey JSON to update internal struct, and return a closure to update the struct again, or an
+	// error
+	//
+	// Note: MetricClosure should only be called once.
 	Update(data convey.C) (MetricClosure, error)
 }
 
-var (
-	validKeyRegex   = regexp.MustCompile(`^[a-zA-Z_:]+$`)
-	replaceRegex    = regexp.MustCompile(`[\W]+`)
-	underscoreRegex = regexp.MustCompile(`_+`)
-)
-
+// NewConveyMetric produces a CMetric where gauge is the internal structure to update, tag is the key in the C JSON
+// to update the gauge, and metricName is the `key` for the gauge cardinality.
+//
+// Note: The Gauge must have the metricName as one of the constant labels
 func NewConveyMetric(gauge metrics.Gauge, tag string, metricName string) CMetric {
 	return &cMetric{
 		tag:   tag,
@@ -29,6 +32,7 @@ func NewConveyMetric(gauge metrics.Gauge, tag string, metricName string) CMetric
 	}
 }
 
+// cMetric is the internal CMetric implementation
 type cMetric struct {
 	tag   string
 	metricName  string
@@ -38,25 +42,9 @@ type cMetric struct {
 func (m *cMetric) Update(data convey.C) (MetricClosure, error) {
 	key := UnknownLabel
 	if item, ok := data[m.tag].(string); ok {
-		key = getValidKeyName(item)
+		key = item
 	}
 
 	m.gauge.With(m.metricName, key).Add(1.0)
 	return func() { m.gauge.With(m.metricName, key).Add(-1.0) }, nil
-}
-
-func getValidKeyName(str string) string {
-	if validKeyRegex.MatchString(str) {
-		return str
-	}
-	str = strings.TrimSpace(str)
-	if str == "" {
-		return UnknownLabel
-	}
-
-	str = replaceRegex.ReplaceAllLiteralString(str, "_")
-	str = strings.Trim(str, "_")
-	str = underscoreRegex.ReplaceAllLiteralString(str, "_")
-
-	return str
 }

--- a/convey/conveymetric/metric_test.go
+++ b/convey/conveymetric/metric_test.go
@@ -15,13 +15,13 @@ func TestConveyMetric(t *testing.T) {
 		Subsystem: "basic",
 	})
 	assert.NoError(err)
-	conveyMetric := NewConveyMetric(registry, "hw_model", "HardwareModel")
+	conveyMetric := NewConveyMetric(registry, "hw-model", "HardwareModel")
 
 	//data, err := registry.Gather()
-	expectedName := "test_basic_HardwareModel_hw_model_hardware123abc"
+	expectedName := "test_basic_HardwareModel_hardware123abc"
 	assert.False(assertConveyMetric(assert, expectedName, registry, float64(-1)), "metric should not be in registry yet")
 
-	dec, err := conveyMetric.Update(convey.C{"data": "neat", "hw_model": "hardware123abc"})
+	dec, err := conveyMetric.Update(convey.C{"data": "neat", "hw-model": "hardware123abc"})
 
 	assert.True(assertConveyMetric(assert, expectedName, registry, float64(1)))
 
@@ -31,7 +31,7 @@ func TestConveyMetric(t *testing.T) {
 	assert.True(assertConveyMetric(assert, expectedName, registry, float64(0)))
 
 	// try with no `hw_model`
-	expectedName = "test_basic_HardwareModel_hw_model_unknown"
+	expectedName = "test_basic_HardwareModel_unknown"
 	dec, err = conveyMetric.Update(convey.C{"data": "neat"})
 	assert.True(assertConveyMetric(assert, expectedName, registry, float64(1)))
 

--- a/convey/conveymetric/metric_test.go
+++ b/convey/conveymetric/metric_test.go
@@ -59,6 +59,7 @@ func TestGetValidKeyName(t *testing.T) {
 	assert := assert.New(t)
 
 	assert.Equal("basic", getValidKeyName("basic"))
+	assert.Equal(UnknownLabel, getValidKeyName(""))
 	assert.Equal(UnknownLabel, getValidKeyName(" "))
 	assert.Equal("hw_model", getValidKeyName("hw-model"))
 	assert.Equal("hw_model", getValidKeyName("hw model"))

--- a/convey/conveymetric/metric_test.go
+++ b/convey/conveymetric/metric_test.go
@@ -34,18 +34,3 @@ func TestConveyMetric(t *testing.T) {
 	dec()
 	assert.Equal(float64(0), gauge.With("model", UnknownLabel).(xmetrics.Valuer).Value())
 }
-
-func TestGetValidKeyName(t *testing.T) {
-	assert := assert.New(t)
-
-	assert.Equal("basic", getValidKeyName("basic"))
-	assert.Equal(UnknownLabel, getValidKeyName(""))
-	assert.Equal(UnknownLabel, getValidKeyName(" "))
-	assert.Equal("hw_model", getValidKeyName("hw-model"))
-	assert.Equal("hw_model", getValidKeyName("hw model"))
-	assert.Equal("hw_model", getValidKeyName("hw	model"))
-	assert.Equal("hw_model", getValidKeyName(" hw	model"))
-	assert.Equal("hw_model", getValidKeyName(" hw	model@"))
-	assert.Equal("hw_model", getValidKeyName("hw@model"))
-	assert.Equal("hw_model", getValidKeyName("hw@ model"))
-}

--- a/convey/conveymetric/metric_test.go
+++ b/convey/conveymetric/metric_test.go
@@ -2,8 +2,7 @@ package conveymetric
 
 import (
 	"github.com/Comcast/webpa-common/convey"
-	"github.com/prometheus/client_golang/prometheus"
-	dto "github.com/prometheus/client_model/go"
+	"github.com/Comcast/webpa-common/xmetrics"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -11,43 +10,49 @@ import (
 func TestConveyMetric(t *testing.T) {
 	assert := assert.New(t)
 
-	conveyMetric := NewConveyMetric("hw_model", "HardwareModel")
-	data := conveyMetric.GetMetrics()
-	assert.Empty(data)
+	registry, err := xmetrics.NewRegistry(&xmetrics.Options{
+		Namespace: "test",
+		Subsystem: "basic",
+	})
+	assert.NoError(err)
+	conveyMetric := NewConveyMetric(registry, "hw_model", "HardwareModel")
+
+	data, err := registry.Gather()
+	currentLen := len(data)
 
 	dec, err := conveyMetric.Update(convey.C{"data": "neat", "hw_model": "apple"})
 	assert.NoError(err)
-	data = conveyMetric.GetMetrics()
-	assert.Len(data, 1)
+	data, err = registry.Gather()
+	assert.NoError(err)
+	assert.True(currentLen < len(data))
+	assert.Len(data[len(data)-1].Metric, 1)
+	assert.Equal("test_basic_HardwareModel_hw_model_apple", *data[len(data)-1].Name)
+	assert.Equal(float64(1), data[len(data)-1].Metric[0].GetGauge().GetValue())
 
-	descChan := make(chan prometheus.Metric, 10)
-	go func() {
-		data[0].Collect(descChan)
-		close(descChan)
-	}()
-
-	for v := range descChan {
-		dtoMetric := &dto.Metric{}
-		err = v.Write(dtoMetric)
-		assert.NoError(err)
-		assert.Equal(dtoMetric.GetGauge().GetValue(), float64(1))
-	}
-	// call back to remove convey from metric
+	// remove the update
 	dec()
-	data = conveyMetric.GetMetrics()
-	assert.Len(data, 1)
 
-	// 0 metric value
-	descChan = make(chan prometheus.Metric, 10)
-	go func() {
-		data[0].Collect(descChan)
-		close(descChan)
-	}()
+	data, err = registry.Gather()
+	assert.NoError(err)
+	assert.Len(data[len(data)-1].Metric, 1)
+	assert.Equal(float64(0), data[len(data)-1].Metric[0].GetGauge().GetValue())
+	currentLen = len(data)
 
-	for v := range descChan {
-		dtoMetric := &dto.Metric{}
-		err = v.Write(dtoMetric)
-		assert.NoError(err)
-		assert.Equal(dtoMetric.GetGauge().GetValue(), float64(0))
-	}
+	// try with now `hw_model`
+	dec, err = conveyMetric.Update(convey.C{"data": "neat"})
+	assert.NoError(err)
+	data, err = registry.Gather()
+	assert.NoError(err)
+	assert.True(currentLen < len(data))
+	assert.Len(data[len(data)-1].Metric, 1)
+	assert.Equal("test_basic_HardwareModel_hw_model_unknown", *data[len(data)-1].Name)
+	assert.Equal(float64(1), data[len(data)-1].Metric[0].GetGauge().GetValue())
+
+	// remove the update
+	dec()
+
+	data, err = registry.Gather()
+	assert.NoError(err)
+	assert.Len(data[len(data)-1].Metric, 1)
+	assert.Equal(float64(0), data[len(data)-1].Metric[0].GetGauge().GetValue())
 }

--- a/convey/conveymetric/metric_test.go
+++ b/convey/conveymetric/metric_test.go
@@ -1,0 +1,53 @@
+package conveymetric
+
+import (
+	"github.com/Comcast/webpa-common/convey"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestConveyMetric(t *testing.T) {
+	assert := assert.New(t)
+
+	conveyMetric := NewConveyMetric("hw_model", "HardwareModel")
+	data := conveyMetric.GetMetrics()
+	assert.Empty(data)
+
+	dec, err := conveyMetric.Update(convey.C{"data": "neat", "hw_model": "apple"})
+	assert.NoError(err)
+	data = conveyMetric.GetMetrics()
+	assert.Len(data, 1)
+
+	descChan := make(chan prometheus.Metric, 10)
+	go func() {
+		data[0].Collect(descChan)
+		close(descChan)
+	}()
+
+	for v := range descChan {
+		dtoMetric := &dto.Metric{}
+		err = v.Write(dtoMetric)
+		assert.NoError(err)
+		assert.Equal(dtoMetric.GetGauge().GetValue(), float64(1))
+	}
+	// call back to remove convey from metric
+	dec()
+	data = conveyMetric.GetMetrics()
+	assert.Len(data, 1)
+
+	// 0 metric value
+	descChan = make(chan prometheus.Metric, 10)
+	go func() {
+		data[0].Collect(descChan)
+		close(descChan)
+	}()
+
+	for v := range descChan {
+		dtoMetric := &dto.Metric{}
+		err = v.Write(dtoMetric)
+		assert.NoError(err)
+		assert.Equal(dtoMetric.GetGauge().GetValue(), float64(0))
+	}
+}

--- a/convey/conveymetric/metric_test.go
+++ b/convey/conveymetric/metric_test.go
@@ -54,3 +54,18 @@ func assertConveyMetric(assert *assert.Assertions, name string, registry xmetric
 
 	return false
 }
+
+func TestGetValidKeyName(t *testing.T) {
+	assert := assert.New(t)
+
+	assert.Equal("basic", getValidKeyName("basic"))
+	assert.Equal(UnknownLabel, getValidKeyName(" "))
+	assert.Equal("hw_model", getValidKeyName("hw-model"))
+	assert.Equal("hw_model", getValidKeyName("hw model"))
+	assert.Equal("hw_model", getValidKeyName("hw	model"))
+	assert.Equal("hw_model", getValidKeyName(" hw	model"))
+	assert.Equal("hw_model", getValidKeyName(" hw	model@"))
+	assert.Equal("hw_model", getValidKeyName("hw@model"))
+	assert.Equal("hw_model", getValidKeyName("hw@ model"))
+
+}

--- a/device/device.go
+++ b/device/device.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"github.com/Comcast/webpa-common/convey/conveymetric"
 	"sync/atomic"
 	"time"
 
@@ -96,6 +97,8 @@ type device struct {
 	shutdown     chan struct{}
 	messages     chan *envelope
 	transactions *Transactions
+
+	conveyClosure conveymetric.MetricClosure
 }
 
 type deviceOptions struct {

--- a/device/device.go
+++ b/device/device.go
@@ -98,7 +98,7 @@ type device struct {
 	messages     chan *envelope
 	transactions *Transactions
 
-	conveyClosure conveymetric.MetricClosure
+	conveyClosure conveymetric.Closure
 }
 
 type deviceOptions struct {

--- a/device/manager.go
+++ b/device/manager.go
@@ -101,7 +101,7 @@ func NewManager(o *Options) Manager {
 			Limit:    o.maxDevices(),
 			Measures: measures,
 		}),
-		conveyHWMetric: conveymetric.NewConveyMetric(o.metricsProvider(), "hw-model", "hardware_model"),
+		conveyHWMetric: conveymetric.NewConveyMetric(o.metricsProvider().NewGauge("hardware"), "hw-model", "model"),
 
 		deviceMessageQueueSize: o.deviceMessageQueueSize(),
 		pingPeriod:             o.pingPeriod(),

--- a/device/manager.go
+++ b/device/manager.go
@@ -123,7 +123,7 @@ type manager struct {
 	conveyTranslator conveyhttp.HeaderTranslator
 
 	devices        *registry
-	conveyHWMetric conveymetric.CMetric
+	conveyHWMetric conveymetric.Interface
 
 	deviceMessageQueueSize int
 	pingPeriod             time.Duration

--- a/device/manager.go
+++ b/device/manager.go
@@ -101,7 +101,7 @@ func NewManager(o *Options) Manager {
 			Limit:    o.maxDevices(),
 			Measures: measures,
 		}),
-		conveyHWMetric: conveymetric.NewConveyMetric(o.metricsProvider(), "hw_model", "hardware_model"),
+		conveyHWMetric: conveymetric.NewConveyMetric(o.metricsProvider(), "hw-model", "hardware_model"),
 
 		deviceMessageQueueSize: o.deviceMessageQueueSize(),
 		pingPeriod:             o.pingPeriod(),

--- a/device/manager.go
+++ b/device/manager.go
@@ -101,7 +101,7 @@ func NewManager(o *Options) Manager {
 			Limit:    o.maxDevices(),
 			Measures: measures,
 		}),
-		conveyHWMetric: conveymetric.NewConveyMetric(o.metricsProvider().NewGauge("hardware"), "hw-model", "model"),
+		conveyHWMetric: conveymetric.NewConveyMetric(measures.Models, "hw-model", "model"),
 
 		deviceMessageQueueSize: o.deviceMessageQueueSize(),
 		pingPeriod:             o.pingPeriod(),

--- a/device/manager.go
+++ b/device/manager.go
@@ -2,6 +2,7 @@ package device
 
 import (
 	"encoding/json"
+	"github.com/Comcast/webpa-common/convey/conveymetric"
 	"io"
 	"net/http"
 	"sync"
@@ -100,6 +101,8 @@ func NewManager(o *Options) Manager {
 			Limit:    o.maxDevices(),
 			Measures: measures,
 		}),
+		conveyHWMetric: conveymetric.NewConveyMetric(o.metricsProvider(), "hw_model", "hardware_model"),
+
 		deviceMessageQueueSize: o.deviceMessageQueueSize(),
 		pingPeriod:             o.pingPeriod(),
 
@@ -119,7 +122,8 @@ type manager struct {
 	upgrader         *websocket.Upgrader
 	conveyTranslator conveyhttp.HeaderTranslator
 
-	devices *registry
+	devices        *registry
+	conveyHWMetric conveymetric.CMetric
 
 	deviceMessageQueueSize int
 	pingPeriod             time.Duration
@@ -185,6 +189,12 @@ func (m *manager) Connect(response http.ResponseWriter, request *http.Request, r
 		}
 	}
 
+	metricClosure, err := m.conveyHWMetric.Update(convey)
+	if err != nil {
+		d.errorLog.Log(logging.MessageKey(), "failed to update convey metrics", logging.ErrorKey(), err)
+	}
+
+	d.conveyClosure = metricClosure
 	m.dispatch(event)
 
 	SetPongHandler(c, m.measures.Pong, m.readDeadline)
@@ -224,6 +234,7 @@ func (m *manager) pumpClose(d *device, c io.Closer, pumpError error) {
 			Device: d,
 		},
 	)
+	d.conveyClosure()
 }
 
 // readPump is the goroutine which handles the stream of WRP messages from a device.

--- a/device/manager_test.go
+++ b/device/manager_test.go
@@ -3,6 +3,8 @@ package device
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/Comcast/webpa-common/convey"
+	"github.com/Comcast/webpa-common/xmetrics"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -367,4 +369,25 @@ func TestManager(t *testing.T) {
 
 	t.Run("Disconnect", testManagerDisconnect)
 	t.Run("DisconnectIf", testManagerDisconnectIf)
+}
+
+func TestGaugeCardinality(t *testing.T) {
+	var (
+		assert = assert.New(t)
+		r, err = xmetrics.NewRegistry(nil, Metrics)
+		m      = NewManager(&Options{
+			MetricsProvider: r,
+		})
+	)
+	assert.NoError(err)
+
+	assert.NotPanics(func() {
+		dec, err := m.(*manager).conveyHWMetric.Update(convey.C{"hw-model": "cardinality", "model": "f"})
+		assert.NoError(err)
+		dec()
+	})
+
+	assert.Panics(func() {
+		m.(*manager).measures.Models.With("neat", "bad").Add(-1)
+	})
 }

--- a/device/metrics.go
+++ b/device/metrics.go
@@ -15,6 +15,7 @@ const (
 	ConnectCounter            = "connect_count"
 	DisconnectCounter         = "disconnect_count"
 	DeviceLimitReachedCounter = "device_limit_reached_count"
+	ModelGauge                = "hardware_model"
 )
 
 // Metrics is the device module function that adds default device metrics
@@ -52,6 +53,11 @@ func Metrics() []xmetrics.Metric {
 			Name: DeviceLimitReachedCounter,
 			Type: "counter",
 		},
+		{
+			Name:       ModelGauge,
+			Type:       "gauge",
+			LabelNames: []string{"model"},
+		},
 	}
 }
 
@@ -65,6 +71,7 @@ type Measures struct {
 	Pong            xmetrics.Incrementer
 	Connect         xmetrics.Incrementer
 	Disconnect      xmetrics.Adder
+	Models          metrics.Gauge
 }
 
 // NewMeasures constructs a Measures given a go-kit metrics Provider
@@ -78,5 +85,6 @@ func NewMeasures(p provider.Provider) Measures {
 		Duplicates:      xmetrics.NewIncrementer(p.NewCounter(DuplicatesCounter)),
 		Connect:         xmetrics.NewIncrementer(p.NewCounter(ConnectCounter)),
 		Disconnect:      p.NewCounter(DisconnectCounter),
+		Models:          p.NewGauge(ModelGauge),
 	}
 }


### PR DESCRIPTION
## What changed
 - Adds the conveymetric package.
    - This package will have a new gauge for each value for a certain key.
    - Then on completion of the convey (aka. disconnect) the `MetricClosure` must be called for accurate results
 - Add conveymetric to device package to track `hw_model`

Required for [Talaria Issue](https://github.com/Comcast/talaria/issues/68)