### PR TITLE
Modified DnsReady() to not error out if SOA provider is empty

### DIFF
--- a/webhook/aws/sns.go
+++ b/webhook/aws/sns.go
@@ -199,6 +199,12 @@ func (ss *SNSServer) PrepareAndStart() {
 //until the timeout is reached
 //if timeout value is 0s it will try forever
 func (ss *SNSServer) DnsReady() (e error) {
+
+	// if an SOA provider isn't given, we're done
+	if ss.SOAProvider == "" {
+		return nil
+	}
+
 	var (
 		ctx    context.Context
 		cancel context.CancelFunc

--- a/webhook/aws/sns_test.go
+++ b/webhook/aws/sns_test.go
@@ -245,3 +245,24 @@ func TestDnsReadySuccess(t *testing.T) {
 
 	assert.NotNil(err)
 }
+
+func TestDnsReadyNoSOASuccess(t *testing.T) {
+	assert := assert.New(t)
+
+	v := SetUpTestViperInstance(TEST_AWS_CFG)
+	ss, err := NewNotifier(v)
+
+	assert.Nil(err)
+	assert.NotNil(ss)
+
+	selfUrl := &url.URL{
+		Scheme: "http",
+		Host:   "host:port",
+	}
+	registry, _ := xmetrics.NewRegistry(&xmetrics.Options{}, Metrics)
+	ss.Initialize(nil, selfUrl, "", nil, nil, registry, func() time.Time { return time.Unix(TEST_UNIX_TIME, 0) })
+
+	err = ss.DnsReady()
+
+	assert.NotNil(err)
+}


### PR DESCRIPTION
If the soa provider given is an empty string, then the DnsReady() function returns without an error.

Closes https://github.com/Comcast/caduceus/issues/111