### PR TITLE
Fix #364: Prevent infinite block on buffered Result channel

### DIFF
--- a/webhook/start.go
+++ b/webhook/start.go
@@ -172,8 +172,7 @@ func (sc *StartConfig) GetCurrentSystemsHooks(rc chan Result) {
 	}
 
 	getHooksChan := make(chan Result, 1)
-	ticker := time.NewTicker(sc.Duration)
-	defer ticker.Stop()
+	timeout := time.After(sc.Duration)
 
 	fn(sc, getHooksChan)
 	for {
@@ -188,7 +187,7 @@ func (sc *StartConfig) GetCurrentSystemsHooks(rc chan Result) {
 				return
 			}
 
-		case <-ticker.C:
+		case <-timeout:
 			rc <- Result{hooks, errors.New("Unable to obtain hook list in allotted time.")}
 			return
 		}

--- a/webhook/start.go
+++ b/webhook/start.go
@@ -154,6 +154,7 @@ func (sc *StartConfig) GetCurrentSystemsHooks(rc chan Result) {
 		err := sc.getAuthorization()
 		if err != nil {
 			rc <- Result{hooks, err}
+			return
 		}
 	}
 


### PR DESCRIPTION
Fix #364 

If sc.Sat.Token is unset and sc.getAuthorization
errors, a Result is sent to rc which fills it.
The function does not return here, so when Results
are sent later in the select section, the
operation blocks function return, even in the
case of Ticker expiration.