### PR TITLE
wrp: add money headers to header_wrp constants

### DIFF
--- a/wrp/header_wrp.go
+++ b/wrp/header_wrp.go
@@ -15,6 +15,8 @@ const (
 	SpansHeader           = "X-Midt-Spans"
 	PathHeader            = "X-Midt-Path"
 	SourceHeader          = "X-Midt-Source"
+	MoneyTraceHeader      = "X-Money-Trace"
+	MoneySpanHeader       = "X-Money-Span"
 )
 
 var ErrInvalidMsgType = errors.New("Invalid Message Type")


### PR DESCRIPTION
appropriate headers for golang-money forwarding (X-Money-Trace) and receiving  (X-Money-Span)