### PR TITLE
Adding Context Aware Handler 

### DIFF
--- a/bookkeeping/bookkeeper_test.go
+++ b/bookkeeping/bookkeeper_test.go
@@ -74,7 +74,7 @@ func TestBookkeeper(t *testing.T) {
 		writer.WriteHeader(200)
 	})
 
-	customLogInfo(bookkeeper(handler)).ServeHTTP(rr, req)
+	bookkeeper(customLogInfo(handler)).ServeHTTP(rr, req)
 
 	assert.True(transactorCalled)
 

--- a/xhttp/xcontext/contextaware_test.go
+++ b/xhttp/xcontext/contextaware_test.go
@@ -1,0 +1,106 @@
+package xcontext
+
+import (
+	"context"
+	"github.com/Comcast/webpa-common/logging"
+	"github.com/justinas/alice"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSetContext(t *testing.T) {
+	assert := assert.New(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer, request = WithContext(writer, request, request.Context())
+
+		assert.Panics(func() {
+			SetContext(writer, nil)
+		})
+		writer = SetContext(writer, context.WithValue(writer.(ContextAware).Context(), "key", "value"))
+		assert.Equal("value", writer.(ContextAware).Context().Value("key"))
+		writer.WriteHeader(200)
+		writer.Write([]byte("Hello World"))
+
+	}))
+	defer server.Close()
+
+	r, err := http.NewRequest("GET", server.URL, nil)
+	assert.NoError(err)
+	r = r.WithContext(logging.WithLogger(r.Context(), logging.New(nil)))
+	response, err := (&http.Client{}).Do(r)
+	assert.NoError(err)
+	assert.NotNil(response)
+}
+
+func TestSingleHandler(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer, request = WithContext(writer, request, request.Context())
+		require.NotNil(writer)
+		require.NotNil(request)
+
+		writer.WriteHeader(200)
+		writer.Write([]byte("Hello World"))
+
+	}))
+	defer server.Close()
+
+	r, err := http.NewRequest("GET", server.URL, nil)
+	assert.NoError(err)
+	r = r.WithContext(logging.WithLogger(r.Context(), logging.New(nil)))
+	response, err := (&http.Client{}).Do(r)
+	assert.NoError(err)
+	assert.NotNil(response)
+}
+
+func TestChain(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	body := "Hello World"
+	bodyKey := "body"
+
+	handler := http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer, request = WithContext(writer, request, request.Context())
+		require.NotNil(writer)
+		require.NotNil(request)
+
+		writer.WriteHeader(200)
+		writer.Write([]byte("Hello World"))
+
+		if writer, ok := writer.(ContextAware); ok {
+			writer.SetContext(context.WithValue(writer.Context(), bodyKey, body))
+		} else {
+			assert.Fail("Writer must be ContextAware")
+		}
+	})
+
+	chain := alice.New(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := Context(w, r)
+			w, r = WithContext(w, r, ctx)
+			next.ServeHTTP(w, r)
+			if writer, ok := w.(ContextAware); ok {
+				assert.Equal(body, writer.Context().Value(bodyKey))
+			} else {
+				assert.Fail("Writer must be ContextAware")
+			}
+		})
+	})
+
+	server := httptest.NewServer(chain.Then(handler))
+	defer server.Close()
+
+	r, err := http.NewRequest("GET", server.URL, nil)
+	assert.NoError(err)
+	r = r.WithContext(logging.WithLogger(r.Context(), logging.New(nil)))
+	response, err := (&http.Client{}).Do(r)
+	assert.NoError(err)
+	assert.NotNil(response)
+}

--- a/xhttp/xcontext/populate.go
+++ b/xhttp/xcontext/populate.go
@@ -18,7 +18,7 @@ func Populate(timeout time.Duration, rf ...gokithttp.RequestFunc) func(http.Hand
 	if timeout > 0 || len(rf) > 0 {
 		return func(next http.Handler) http.Handler {
 			return http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
-				ctx := request.Context()
+				ctx := Context(response, request)
 				for _, f := range rf {
 					ctx = f(ctx, request)
 				}
@@ -28,8 +28,8 @@ func Populate(timeout time.Duration, rf ...gokithttp.RequestFunc) func(http.Hand
 					ctx, cancel = context.WithTimeout(ctx, timeout)
 					defer cancel()
 				}
-
-				next.ServeHTTP(response, request.WithContext(ctx))
+				response, request = WithContext(response, request, ctx)
+				next.ServeHTTP(response, request)
 			})
 		}
 	}


### PR DESCRIPTION
This allows for the context to be passed up through the chain. Thus allowing the bookkeeper library to be the top decorator in a chain.