### PR TITLE
Return a well-known error when no watches or registrations are config…

### DIFF
--- a/service/consul/environment.go
+++ b/service/consul/environment.go
@@ -191,7 +191,7 @@ func NewEnvironment(l log.Logger, registrationScheme string, co Options, eo ...s
 	}
 
 	if len(co.Watches) == 0 && len(co.Registrations) == 0 {
-		return nil, nil
+		return nil, service.ErrIncomplete
 	}
 
 	consulClient, err := api.NewClient(co.config())

--- a/service/consul/environment_test.go
+++ b/service/consul/environment_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/Comcast/webpa-common/logging"
+	"github.com/Comcast/webpa-common/service"
 	"github.com/hashicorp/consul/api"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -20,7 +21,7 @@ func testNewEnvironmentEmpty(t *testing.T) {
 
 	e, err := NewEnvironment(nil, "http", Options{})
 	assert.Nil(e)
-	assert.NoError(err)
+	assert.Equal(service.ErrIncomplete, err)
 
 	clientFactory.AssertExpectations(t)
 }

--- a/service/environment.go
+++ b/service/environment.go
@@ -1,10 +1,18 @@
 package service
 
 import (
+	"errors"
 	"io"
 	"sync"
 
 	"github.com/go-kit/kit/sd"
+)
+
+var (
+	// ErrIncomplete is returned by platform-specific code that creates environments
+	// whenever the configuration is incomplete: it contains connection information
+	// but no watches or registrations.
+	ErrIncomplete = errors.New("No watches or registrations configured")
 )
 
 // NopCloser is a closer function that does nothing.  It always returns a nil error.  Useful

--- a/service/zk/environment.go
+++ b/service/zk/environment.go
@@ -89,7 +89,7 @@ func NewEnvironment(l log.Logger, zo Options, eo ...service.Option) (service.Env
 	}
 
 	if len(zo.Watches) == 0 && len(zo.Registrations) == 0 {
-		return nil, nil
+		return nil, service.ErrIncomplete
 	}
 
 	c, err := newClient(l, zo)

--- a/service/zk/environment_test.go
+++ b/service/zk/environment_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/Comcast/webpa-common/logging"
+	"github.com/Comcast/webpa-common/service"
 	"github.com/go-kit/kit/log"
 	gokitzk "github.com/go-kit/kit/sd/zk"
 	"github.com/samuel/go-zookeeper/zk"
@@ -23,7 +24,7 @@ func testNewEnvironmentEmpty(t *testing.T) {
 
 	e, err := NewEnvironment(nil, Options{})
 	assert.Nil(e)
-	assert.NoError(err)
+	assert.Equal(service.ErrIncomplete, err)
 
 	clientFactory.AssertExpectations(t)
 }


### PR DESCRIPTION
…ured